### PR TITLE
Implement support for downloading elevation geotiffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,45 @@ Then install rasterio with pip
 ```cmd
 python -m pip install rasterio
 ```
+
+## Elevation from the USGS National Map (download-elevation)
+
+The National Map platform exposes a `3DEPElevation` ImageServer that returns
+georeferenced Float32 elevation GeoTIFFs through the same `exportImage`
+mechanism the ortho path uses. This repo registers it as an `"elevation"`
+service and provides a `download-elevation` command that fetches F32 DEM
+chunks over the shape AOI and mosaics them into one continuous GeoTIFF
+(`elevation_merged.tif`) that feeds the existing `gather-ortho -src arcgis -e`
+/ `prep-geo` pipeline.
+
+### Prereqs: build the service registry
+
+The service registry (coverage + native resolution + capability kinds per
+layer) is fetched from the shipped endpoint list and cached:
+
+```cmd
+python -m terrain_stitcher refresh-services
+```
+
+### Download a continuous elevation raster
+
+```cmd
+python -m terrain_stitcher download-elevation -s Shape.json -o elevation_merged.tif
+```
+
+Options:
+
+- `-s/--shape` (required): shape file defining the AOI.
+- `-o/--output`: path for the merged GeoTIFF (default `elevation_merged.tif`).
+- `--res <m/px>`: fetch resolution (defaults to the service's registered
+  native pixel size, 10.0 m for 3DEP). A finer value only warns, since 3DEP
+  resamples on the fly.
+- `--chunk-px`, `--timeout`, `-w/--workers`: download tuning (same defaults
+  as `download-arcgis`).
+- `--service-index <N>`: pick one when several elevation services cover the AOI.
+- `--padding <deg>`: optional degrees of padding around the AOI (default 0).
+
+`download-arcgis` continues to select only `"imagery"` services, so it never
+picks the elevation endpoint. `download-elevation` never produces a tile
+pyramid; elevation is a continuous raster, so it writes a single merged
+GeoTIFF instead of running gdal2tiles.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "terrain_stitcher"
-version = "0.2.1"
+version = "0.2.2"
 description = "Terrain Scraper"
 requires-python = ">=3.9"
 dependencies = [
@@ -17,6 +17,7 @@ dependencies = [
     "rasterio>=1.4.3",
     "shapely>=2.0.7",
     "psutil>=5.9.0",
+    "platformdirs>=4.2.0",
     "tqdm>=4.67.3",
 ]
 
@@ -31,6 +32,9 @@ allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/terrain_stitcher"]
+
+[tool.hatch.build.targets.wheel.force-include]
+"src/terrain_stitcher/arcgis/services_to_scan.json" = "terrain_stitcher/arcgis/services_to_scan.json"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/terrain_stitcher/arcgis/services.py
+++ b/src/terrain_stitcher/arcgis/services.py
@@ -1,0 +1,462 @@
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+APP_NAME = "terrain-stitcher"
+CACHE_FILENAME = "services.json"
+SCAN_FILENAME = "services_to_scan.json"
+
+# Valid capability kinds a registered ArcGIS raster service may declare. A
+# service can carry one or both; ``"imagery"`` feeds download-arcgis and
+# ``"elevation"`` feeds download-elevation.
+KIND_IMAGERY = "imagery"
+KIND_ELEVATION = "elevation"
+DEFAULT_KINDS = (KIND_IMAGERY,)
+
+
+@dataclass(frozen=True)
+class ImageryService:
+    """A single ArcGIS ImageServer raster layer (orthoimagery or elevation).
+
+    ``coverage`` is a WGS84 bounding box stored as
+    ``(min_lat, min_lon, max_lat, max_lon)``. It is used both to select the
+    right layer for a given AOI (by center containment) and to validate that
+    the whole AOI fits inside the layer's footprint.
+
+    ``kinds`` lists the capabilities this layer supports -- any subset of
+    ``["imagery", "elevation"]``. Imagery services are selected by
+    ``download-arcgis``, elevation services by ``download-elevation``. It
+    defaults to ``["imagery"]`` so legacy cache entries (written before this
+    field existed) keep resolving as imagery-only.
+    """
+
+    key: str
+    label: str
+    base_url: str
+    native_pixel_size_m: float
+    srs: int
+    coverage: tuple[float, float, float, float]
+    kinds: list[str] = field(default_factory=lambda: list(DEFAULT_KINDS))
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "ImageryService":
+        cov = d["coverage"]
+        kinds = d.get("kinds")
+        if kinds is None:
+            kinds = list(DEFAULT_KINDS)
+        return cls(
+            key=d["key"],
+            label=d["label"],
+            base_url=d["base_url"],
+            native_pixel_size_m=float(d["native_pixel_size_m"]),
+            srs=int(d["srs"]),
+            coverage=(float(cov[0]), float(cov[1]), float(cov[2]), float(cov[3])),
+            kinds=list(kinds),
+        )
+
+    def to_dict(self) -> dict:
+        d = asdict(self)
+        d["coverage"] = list(self.coverage)
+        return d
+
+    def supports_kind(self, kind: str) -> bool:
+        return kind in self.kinds
+
+    def contains_point(self, lat: float, lon: float) -> bool:
+        min_lat, min_lon, max_lat, max_lon = self.coverage
+        return min_lat <= lat <= max_lat and min_lon <= lon <= max_lon
+
+    def contains_bbox(self, aoi: tuple[float, float, float, float]) -> bool:
+        min_lat, min_lon, max_lat, max_lon = aoi
+        c_min_lat, c_min_lon, c_max_lat, c_max_lon = self.coverage
+        return (
+            min_lat >= c_min_lat
+            and max_lat <= c_max_lat
+            and min_lon >= c_min_lon
+            and max_lon <= c_max_lon
+        )
+
+
+def bbox_latlon_from_radius(
+    lat: float, lon: float, radius_miles: float
+) -> tuple[float, float, float, float]:
+    """WGS84 bbox ``(min_lat, min_lon, max_lat, max_lon)`` for a radius in
+    miles around ``lat/lon``. Mirrors ``OrthoDownloader.bbox_from_radius``
+    but stays in lat/lon for service selection / coverage checks."""
+    radius_m = float(radius_miles) * 1609.344
+    meters_per_deg_lat = 111_320.0
+    meters_per_deg_lon = 111_320.0 * math.cos(math.radians(lat))
+    dlat = radius_m / meters_per_deg_lat
+    dlon = radius_m / meters_per_deg_lon
+    return (lat - dlat, lon - dlon, lat + dlat, lon + dlon)
+
+
+class AmbiguousServiceError(ValueError):
+    """Raised by :func:`select_service` when more than one registered
+    service of the requested kind fully covers the AOI and no ``index`` was
+    supplied to disambiguate. The ordered candidate list is attached as
+    ``candidates`` so the caller can present it for selection."""
+
+    def __init__(self, candidates, kind: str = "imagery", message: str = ""):
+        self.candidates = list(candidates)
+        self.kind = kind
+        super().__init__(
+            message
+            or f"AOI is covered by multiple {kind} services; pass an index "
+            "to select one. Candidates: " + ", ".join(s.key for s in self.candidates)
+        )
+
+
+def _kind_label(kind: str) -> str:
+    return kind or "imagery"
+
+
+def _covering_services(
+    services: dict[str, ImageryService],
+    aoi_bbox: tuple[float, float, float, float],
+    kind: str = KIND_IMAGERY,
+) -> list[ImageryService]:
+    """Return the registered services of *kind* that fully cover the AOI,
+    ordered by ``key`` for stable index-based selection.
+
+    Only services whose ``kinds`` includes *kind* are considered. Raises
+    ``ValueError`` if no such service contains the AOI center, or if the
+    center is inside one or more of them but the whole AOI extends outside
+    every one of them (i.e. the view distance is too large for any single
+    service).
+    """
+    label = _kind_label(kind)
+    candidates = [s for s in services.values() if s.supports_kind(kind)]
+    if not candidates:
+        raise ValueError(
+            f"No {label} services are cached. Run `terrain-stitcher "
+            "refresh-services` to build the registry from the shipped "
+            "endpoint list (services_to_scan.json), then re-run your "
+            "download command."
+        )
+    min_lat, min_lon, max_lat, max_lon = aoi_bbox
+    cx_lat = (min_lat + max_lat) / 2.0
+    cx_lon = (min_lon + max_lon) / 2.0
+
+    hits = [s for s in candidates if s.contains_point(cx_lat, cx_lon)]
+    if not hits:
+        raise ValueError(
+            f"AOI center ({cx_lat:.4f}, {cx_lon:.4f}) is not inside any "
+            f"registered {label} service coverage. Registered {label} "
+            f"services: " + ", ".join(s.key for s in candidates)
+        )
+    fully = [s for s in hits if s.contains_bbox(aoi_bbox)]
+    if not fully:
+        raise ValueError(
+            f"AOI center ({cx_lat:.4f}, {cx_lon:.4f}) is inside "
+            f"{', '.join(s.key for s in hits)}, but the AOI extends "
+            f"outside every covering {label} service (AOI {aoi_bbox}). "
+            f"Reduce the view distance or move the center so the whole AOI "
+            f"fits inside a single service."
+        )
+    return sorted(fully, key=lambda s: s.key)
+
+
+def select_service(
+    services: dict[str, ImageryService],
+    aoi_bbox: tuple[float, float, float, float],
+    index: int | None = None,
+    kind: str = KIND_IMAGERY,
+) -> ImageryService:
+    """Pick the service to download from for an AOI, restricted to those
+    that support *kind* (``"imagery"`` or ``"elevation"``).
+
+    Candidates are the services of that kind whose coverage fully contains
+    the AOI (center inside the footprint and the whole AOI bbox inside it).
+    When exactly one service qualifies it is returned. When more than one
+    qualifies the caller must disambiguate: pass ``index`` (0-based, into
+    the ordered candidate list) to pick one, or omit it to raise
+    :class:`AmbiguousServiceError` carrying the candidates so the CLI can
+    print them and ask the user to re-run with ``--service-index``.
+
+    Raises ``ValueError`` if no service of that kind covers the AOI center,
+    if the AOI extends outside every covering service, or if ``index`` is
+    out of range.
+    """
+    candidates = _covering_services(services, aoi_bbox, kind=kind)
+    if index is not None:
+        if not (0 <= index < len(candidates)):
+            raise ValueError(
+                f"service index {index} is out of range; "
+                f"{len(candidates)} service(s) cover this AOI "
+                f"(valid indices 0..{len(candidates) - 1}): "
+                + ", ".join(s.key for s in candidates)
+            )
+        return candidates[index]
+    if len(candidates) == 1:
+        return candidates[0]
+    raise AmbiguousServiceError(candidates, kind=kind)
+
+
+# --- Registry persistence ---------------------------------------------------
+
+
+def _cache_path() -> Path | None:
+    try:
+        from platformdirs import user_cache_dir
+    except ImportError:
+        return None
+    return Path(user_cache_dir(APP_NAME)) / CACHE_FILENAME
+
+
+def _shipped_scan_items() -> list:
+    """Read the endpoint scan list shipped with the package
+    (``services_to_scan.json``) and return its array of entries."""
+    from importlib.resources import files
+
+    raw = files("terrain_stitcher.arcgis").joinpath(SCAN_FILENAME).read_bytes()
+    data = json.loads(raw)
+    if isinstance(data, dict):
+        items = data.get("folders") or data.get("endpoints") or []
+    else:
+        items = data
+    if not isinstance(items, list):
+        raise ValueError(
+            "shipped services_to_scan.json must contain a JSON array of "
+            "endpoints (or an object with a 'folders' array)"
+        )
+    return items
+
+
+def _parse_services(data: dict) -> dict[str, ImageryService]:
+    out: dict[str, ImageryService] = {}
+    for entry in data.get("services", []):
+        svc = ImageryService.from_dict(entry)
+        out[svc.key] = svc
+    return out
+
+
+def load_services() -> dict[str, ImageryService]:
+    """Load the cached service registry (written by ``refresh-services``).
+
+    The registry is generated at runtime from the shipped endpoint scan list
+    (``services_to_scan.json``); it is not shipped pre-resolved. If no cache
+    exists yet, an empty dict is returned and :func:`select_service` directs
+    the user to run ``refresh-services``.
+    """
+    cache = _cache_path()
+    if cache is not None and cache.is_file():
+        try:
+            data = json.loads(cache.read_bytes())
+        except (json.JSONDecodeError, OSError):
+            data = None
+        if data is not None:
+            return _parse_services(data)
+    return {}
+
+
+def save_services(data: dict, path) -> Path:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+# --- Live harvesting from the ArcGIS REST directory -------------------------
+
+
+def _coverage_from_extent(extent) -> tuple[float, float, float, float]:
+    from pyproj import Transformer
+
+    if not extent:
+        raise ValueError("service metadata has no fullExtent/extent")
+    sr = extent.get("spatialReference", {}) or {}
+    wkid = sr.get("latestWkid") or sr.get("wkid")
+    if wkid == 102100:
+        wkid = 3857
+    transformer = Transformer.from_crs(f"EPSG:{wkid}", "EPSG:4326", always_xy=True)
+    lats, lons = [], []
+    for x in (extent["xmin"], extent["xmax"]):
+        for y in (extent["ymin"], extent["ymax"]):
+            lo, la = transformer.transform(x, y)
+            lons.append(lo)
+            lats.append(la)
+    return (min(lats), min(lons), max(lats), max(lons))
+
+
+def _native_pixel_size(meta: dict) -> float:
+    """Best-effort native resolution (m/px) from service metadata.
+
+    Tries, in order: the finest cached LOD resolution, ``minPixelSize``,
+    then the mosaic cell size (``pixelSizeX`` / ``meanPixelSize``). A
+    ``minPixelSize`` of 0 (common on mosaic datasets, meaning "no minimum
+    constraint") is treated as absent. Raises ``ValueError`` only when none
+    are present -- in which case the scan-list entry should declare
+    ``pixel_size`` explicitly.
+    """
+    tile_info = meta.get("tileInfo")
+    if tile_info and tile_info.get("lods"):
+        return float(min(lod["resolution"] for lod in tile_info["lods"]))
+    if meta.get("minPixelSize"):
+        return float(meta["minPixelSize"])
+    for key in ("pixelSizeX", "meanPixelSize"):
+        if meta.get(key):
+            return float(meta[key])
+    raise ValueError(
+        "service has no tileInfo.lods, minPixelSize, pixelSizeX, or "
+        "meanPixelSize; native resolution could not be determined. "
+        "Declare 'pixel_size' on the scan-list entry to register it."
+    )
+
+
+def _endpoint_url(item) -> str:
+    """Normalize a scan-list entry to an ImageServer URL (strip a trailing
+    ``/exportImage`` if present). Accepts a plain URL string or an object
+    with a ``url`` key."""
+    if isinstance(item, str):
+        url = item
+    elif isinstance(item, dict):
+        url = item.get("url")
+        if not url:
+            raise ValueError(f"endpoint entry missing 'url': {item!r}")
+    else:
+        raise ValueError(
+            f"unsupported endpoint entry type {type(item).__name__}: {item!r}"
+        )
+    url = url.rstrip("/")
+    if url.endswith("/exportImage"):
+        url = url[: -len("/exportImage")]
+    return url
+
+
+def _item_pixel_size(item) -> float | None:
+    """Return the native pixel size (m/px) declared on a scan-list entry, if
+    any. Only object entries may carry a ``pixel_size`` field; plain URL
+    strings cannot, in which case ``None`` is returned and the size is
+    derived from the service metadata instead."""
+    if isinstance(item, dict):
+        ps = item.get("pixel_size")
+        if ps is not None:
+            return float(ps)
+    return None
+
+
+def _item_kinds(item) -> list[str]:
+    """Return the capability ``kinds`` declared on a scan-list entry, if any.
+
+    Only object entries may carry a ``kinds`` list (e.g. ``["elevation"]``);
+    plain URL strings (and objects that omit it) default to ``["imagery"]``.
+    Unknown values are filtered out so a typo degrades to the default rather
+    than registering a capability the downloaders don't understand.
+    """
+    valid = {KIND_IMAGERY, KIND_ELEVATION}
+    if isinstance(item, dict):
+        kinds = item.get("kinds")
+        if kinds:
+            return [k for k in kinds if k in valid] or list(DEFAULT_KINDS)
+    return list(DEFAULT_KINDS)
+
+
+def harvest_from_items(items, timeout: int = 30) -> dict:
+    """Build a registry by fetching each ImageServer endpoint's metadata.
+
+    ``items`` is an array of endpoint entries: URL strings (pointing at an
+    ArcGIS ``.../ImageServer`` resource, with or without a trailing
+    ``/exportImage``) or objects. An object must have a ``url`` key and may
+    also declare ``pixel_size`` (m/px) and ``kinds`` (list of capability
+    kinds, defaulting to ``["imagery"]``). When present, ``pixel_size`` is
+    used as the service's native resolution instead of reading it from the
+    metadata -- this lets uncached / mosaic services (which expose no
+    ``tileInfo`` and a meaningless ``minPixelSize`` of 0, e.g. USGSNAIPPlus)
+    be registered with their real cell size.
+
+    Each entry's ``fullExtent`` (coverage) is always read from the metadata;
+    only the resolution and capability kinds may be supplied statically. No
+    folder crawling, so the scan list is exactly the set of services to
+    register.
+    """
+    import requests
+
+    services: list[dict] = []
+    seen_keys: set[str] = set()
+    endpoints: list[str] = []
+    for item in items:
+        base = _endpoint_url(item)
+        endpoints.append(base)
+        declared = _item_pixel_size(item)
+        kinds = _item_kinds(item)
+        meta = requests.get(base, params={"f": "json"}, timeout=timeout).json()
+        extent = meta.get("fullExtent") or meta.get("extent")
+        sr = (extent or {}).get("spatialReference", {}) or {}
+        srs = int(sr.get("latestWkid") or sr.get("wkid") or 3857)
+        # Derive a stable, server-unique key from the service path; the leaf
+        # name is prettified for the human-readable label.
+        stem = base
+        if "://" in stem:
+            stem = stem.split("://", 1)[1]
+        key = stem.replace("/", "__")
+        if key in seen_keys:
+            print(f"Skipping duplicate service key {key} ({base})")
+            continue
+        seen_keys.add(key)
+        leaf = stem.rsplit("/", 1)[-1]
+        try:
+            cov = _coverage_from_extent(extent)
+            nps = declared if declared is not None else _native_pixel_size(meta)
+        except ValueError as e:
+            print(f"Skipping {base}: {e}")
+            continue
+        services.append(
+            ImageryService(
+                key=key,
+                label=leaf.replace("_", " ").title(),
+                base_url=f"{base}/exportImage",
+                native_pixel_size_m=nps,
+                srs=srs,
+                coverage=cov,
+                kinds=kinds,
+            ).to_dict()
+        )
+    return {"services": services, "_endpoints": endpoints}
+
+
+def harvest_from_file(path, timeout: int = 30) -> dict:
+    """Build a registry from a JSON file containing an array of ImageServer
+    endpoints to register. Each entry is a URL string or an object
+    ``{"url": ...}`` (optionally with ``"pixel_size": <m/px>`` to declare
+    the native resolution statically, and ``"kinds"`` to declare the
+    capability kinds). A top-level object with a ``"folders"`` array is also
+    accepted for compatibility.
+    """
+    data = json.loads(Path(path).read_bytes())
+    if isinstance(data, dict):
+        items = data.get("folders") or data.get("endpoints") or []
+    else:
+        items = data
+    if not isinstance(items, list):
+        raise ValueError(
+            "services file must contain a JSON array of endpoints (or an "
+            "object with a 'folders' array)"
+        )
+    return harvest_from_items(items, timeout=timeout)
+
+
+def refresh_services(timeout: int = 30, from_file=None) -> Path:
+    """Fetch each endpoint's metadata and write the resolved registry to the
+    user cache dir so ``load_services`` picks it up on subsequent runs.
+
+    With no arguments, the endpoints are read from the scan list shipped with
+    the package (``services_to_scan.json``). Pass ``from_file`` to use a
+    custom scan-list file instead.
+    """
+    if from_file:
+        data = harvest_from_file(from_file, timeout=timeout)
+    else:
+        data = harvest_from_items(_shipped_scan_items(), timeout=timeout)
+    cache = _cache_path()
+    if cache is None:
+        raise RuntimeError("platformdirs is not installed; cannot write a cache.")
+    save_services(data, cache)
+    print(
+        f"Refreshed {len(data['services'])} service(s) -> {cache}\n"
+        f"download-arcgis / download-elevation will use this cached registry."
+    )
+    return cache

--- a/src/terrain_stitcher/cli.py
+++ b/src/terrain_stitcher/cli.py
@@ -1,4 +1,4 @@
-import argparse
+﻿import argparse
 
 from terrain_stitcher.functions import (
     main_ortho,
@@ -8,56 +8,140 @@ from terrain_stitcher.functions import (
     main_prep_ortho,
     main_prep_elevation,
     main_prep_geo,
-    main_ortho,
     main_stitch_ortho,
     main_arcgis_downloader,
+    main_elevation,
 )
 
 
 def addCreateBoundsGeneratorArgs(subparser):
-    parserGenerate = subparser.add_parser("create-bounds")
+    parserGenerate = subparser.add_parser(
+        "create-bounds",
+        help="Generate a Shape.json bounds file around a center point",
+        description=(
+            "Generate a Shape.json bounds file that every other command uses "
+            "to define the area of interest (AOI). The bounds are computed as "
+            "a square region centered on -lat/-lon and sized by "
+            "-vd/--viewDistance (radius in miles). The file is written to "
+            "Shape.json in the current working directory."
+        ),
+    )
 
-    parserGenerate.add_argument("-lat", "--lat", help="center latitude degrees")
-    parserGenerate.add_argument("-lon", "--lon", help="center longitude degrees")
     parserGenerate.add_argument(
-        "-t", "--type", help="type of generation approach to use. Such as POINT"
+        "-lat",
+        "--lat",
+        help=(
+            "Center latitude in decimal degrees (must be between -90 and 90). "
+            "This is the north/south center of the generated bounds region "
+            "and is stored in Shape.json as the AOI center."
+        ),
+    )
+    parserGenerate.add_argument(
+        "-lon",
+        "--lon",
+        help=(
+            "Center longitude in decimal degrees (must be between -180 and "
+            "180). This is the east/west center of the generated bounds "
+            "region and is stored in Shape.json as the AOI center."
+        ),
+    )
+    parserGenerate.add_argument(
+        "-t",
+        "--type",
+        help=(
+            "Type of generation approach to use. Currently only 'POINT' is "
+            "supported: it creates a square bounding box around the center "
+            "point using --viewDistance as the radius."
+        ),
     )
     parserGenerate.add_argument(
         "-vd",
         "--viewDistance",
         type=float,
         default=None,
-        help="View distance in miles used to size the bounds region (default: 10)",
+        help=(
+            "View distance in miles used to size the bounds region (default: "
+            "10). The radius is converted to degrees (lat offset = miles / 69; "
+            "lon offset is additionally divided by cos(latitude)) and the "
+            "resulting square region is written to Shape.json as "
+            "'view_distance'."
+        ),
     )
 
 
 def addDownloadOrthoArgs(subparser):
-    parserGenerate = subparser.add_parser("gather-ortho")
+    parserGenerate = subparser.add_parser(
+        "gather-ortho",
+        help=(
+            "Gather orthoimagery for a shape AOI (USGS download or ArcGIS "
+            "cache import)"
+        ),
+        description=(
+            "Gather orthoimagery covering the shape AOI. With -src usgs "
+            "(default) the USGS Earth Explorer M2M API is queried and the "
+            "matching high-resolution ortho scenes are downloaded as zips + "
+            "sidecar JSONs into the output directory. With -src arcgis the "
+            "command imports an existing local tile cache (see -i/--input and "
+            "--from-download) and stitches it directly into merged PNGs plus a "
+            "height_info.json manifest, folding the old prep-ortho + "
+            "stitch-ortho stages into one pass."
+        ),
+    )
 
     parserGenerate.add_argument(
-        "-o", "--output", help="Directory to place gathered files"
+        "-o",
+        "--output",
+        help=(
+            "Directory to place gathered files. For usgs: downloaded ortho "
+            "zips + sidecar JSONs. For arcgis: stitched gathered_r*_c*.png "
+            "images, a height_info.json manifest, and (with -e) "
+            "elevation_merged.tif."
+        ),
     )
     parserGenerate.add_argument(
-        "-s", "--shape", help="Shape file defining area for generation"
+        "-s",
+        "--shape",
+        help=(
+            "Shape file (Shape.json, produced by create-bounds) defining the "
+            "area of interest. For usgs it is the region queried against the "
+            "USGS API; for arcgis it filters the cache tiles to those whose "
+            "footprint overlaps the region."
+        ),
     )
     parserGenerate.add_argument(
         "-src",
         "--source",
         choices=["usgs", "arcgis"],
         default="usgs",
-        help="Acquisition source to use (default: usgs)",
+        help=(
+            "Acquisition source to use (default: usgs). 'usgs' downloads "
+            "high-resolution ortho scenes from the USGS Earth Explorer M2M "
+            "API. 'arcgis' imports tiles that already exist on disk (requires "
+            "-i/--input) and stitches them in one pass."
+        ),
     )
     parserGenerate.add_argument(
         "-i",
         "--input",
-        help="Source directory for local imports (required for arcgis)",
+        help=(
+            "Source directory for local imports (required for arcgis). Either "
+            "a gdal2tiles XYZ output produced by `download-arcgis` (add "
+            "--from-download) or an ArcGIS Pro exploded tile cache containing "
+            "conf.xml + _alllayers. Ignored for the usgs source."
+        ),
     )
     parserGenerate.add_argument(
         "-w",
         "--workers",
         type=int,
         default=None,
-        help="Number of long-lived worker subprocesses for arcgis gather (default: os.cpu_count()).",
+        help=(
+            "Number of long-lived worker subprocesses for arcgis gather "
+            "(default: os.cpu_count()). Used for tile discovery (one worker "
+            "per cache row) and for stitching; each worker holds one group's "
+            "canvas in memory, so lower this if a run exhausts memory. Ignored "
+            "for the usgs source."
+        ),
     )
     # The following options apply to the arcgis source only, which folds the
     # old prep-ortho + stitch-ortho stages into the import: the cache native
@@ -68,167 +152,525 @@ def addDownloadOrthoArgs(subparser):
         "--dimension",
         type=int,
         default=1,
-        help="arcgis only: square side length to combine (2 = 2x2 -> 1 image). "
-        "1 = passthrough (default).",
+        help=(
+            "arcgis only: square side length to combine (2 = 2x2 -> 1 image). "
+            "1 = passthrough (default). The cache's native (row, col) grid is "
+            "partitioned into N x N windows; each window becomes one output "
+            "image (gathered_r*_c*.png). Partial edge windows and windows with "
+            "holes produce smaller/ragged images with absent cells left blank."
+        ),
     )
     parserGenerate.add_argument(
         "-f",
         "--scaleFactor",
         type=float,
         default=1.0,
-        help="arcgis only: downscale each tile by this fraction during "
-        "stitching (0.0 < value <= 1.0; 1.0 = no scaling).",
+        help=(
+            "arcgis only: downscale each tile by this fraction during "
+            "stitching (0.0 < value <= 1.0; 1.0 = no scaling). Only "
+            "downscaling is supported. Resampling is LANCZOS; for scale "
+            "factors at or below 0.25, PIL's progressive reduction "
+            "(reducing_gap) is used to avoid moire and speed up large "
+            "downscales."
+        ),
     )
     parserGenerate.add_argument(
         "--resume",
         action="store_true",
         default=False,
-        help="arcgis only: skip groups whose stitched output already exists.",
+        help=(
+            "arcgis only: skip groups whose stitched output already exists. "
+            "Outputs are written atomically (temp-then-replace), so an "
+            "existing file is always a complete write from a prior run. Use "
+            "this to continue an interrupted stitch instead of re-doing "
+            "finished groups."
+        ),
     )
     parserGenerate.add_argument(
         "-e",
         "--elevationDataDir",
         default=None,
-        help="arcgis only: directory of elevation GeoTIFFs covering the shape "
-        "AOI. They are clipped and composited into one continuous GeoTIFF "
-        "(elevation_merged.tif) in the output and recorded in the manifest, "
-        "mirroring prep-geo. Fails if no tile intersects the AOI.",
+        help=(
+            "arcgis only: directory of elevation GeoTIFFs covering the shape "
+            "AOI. They are clipped to the shape region (plus --padding) and "
+            "composited into one continuous EPSG:4326 GeoTIFF "
+            "(elevation_merged.tif) in the output, recorded in "
+            "height_info.json under elevation_files, mirroring prep-geo. "
+            "Fails if no tile intersects the AOI."
+        ),
     )
     parserGenerate.add_argument(
         "--lod_min",
         type=int,
         default=None,
-        help="arcgis only: lowest cache level of detail to stitch. When omitted the "
-        "highest LOD with surviving tiles is used.",
+        help=(
+            "arcgis only: lowest cache level of detail to stitch. For an "
+            "ArcGIS Pro cache import this selects the single LOD to stitch (a "
+            "cache ships every LOD it was built at, so scoping to one keeps "
+            "the (row, col) grid non-overlapping). For --from-download "
+            "imports it is the lowest XYZ zoom level to consider and the LOD "
+            "that is stitched. When omitted, the highest LOD with surviving "
+            "tiles is used."
+        ),
     )
     parserGenerate.add_argument(
         "--lod_max",
         type=int,
         default=None,
-        help="arcgis only: highest cache level of detail to stitch to. When omitted the "
-        "highest LOD with surviving tiles is used.",
+        help=(
+            "arcgis only: highest cache level of detail to consider. Only "
+            "used with --from-download imports, where it bounds the XYZ zoom "
+            "range of the tile scheme. When omitted, the highest LOD with "
+            "surviving tiles is used. Ignored for ArcGIS Pro cache imports."
+        ),
     )
     parserGenerate.add_argument(
         "--padding",
         type=float,
         default=None,
-        help="arcgis only: degrees of padding around the shape AOI when merging "
-        "elevation GeoTIFFs (-e) into one continuous GeoTIFF (default: 0.1, ~1km "
-        "at mid-latitudes). Mirrors prep-geo --padding.",
+        help=(
+            "arcgis only: degrees of padding added around the shape AOI when "
+            "merging elevation GeoTIFFs (-e) into one continuous GeoTIFF "
+            "(default: 0.1, ~1km at mid-latitudes). Mirrors prep-geo "
+            "--padding; keeps downstream consumers from seeing NoData exactly "
+            "at the region edge."
+        ),
     )
     parserGenerate.add_argument(
         "--from-download",
         action="store_true",
         default=False,
-        help="arcgis only: import a gdal2tiles XYZ output produced by the "
-        "`download-arcgis` command (point -i at it). Without this flag, -i "
-        "is treated as an ArcGIS Pro exploded tile cache (conf.xml + "
-        "_alllayers).",
+        help=(
+            "arcgis only: import a gdal2tiles XYZ output produced by the "
+            "`download-arcgis` command (point -i at it). Without this flag, "
+            "-i is treated as an ArcGIS Pro exploded tile cache (conf.xml + "
+            "_alllayers). XYZ tiles live at <z>/<x>/<y>.png; cache tiles at "
+            "L##/R########/C########.png."
+        ),
     )
 
 
 def addDownloadArcgisArgs(subparser):
-    parserGenerate = subparser.add_parser("download-arcgis")
+    parserGenerate = subparser.add_parser(
+        "download-arcgis",
+        help=(
+            "Download orthoimagery from an ArcGIS imagery service and tile it "
+            "with gdal2tiles"
+        ),
+        description=(
+            "Download orthoimagery over the shape AOI from a registered "
+            "ArcGIS imagery service (see refresh-services) and tile the "
+            "resulting mosaic with gdal2tiles into a Web Mercator tile cache. "
+            "The output can be imported later with `gather-ortho -src arcgis "
+            "--from-download -i <output>`."
+        ),
+    )
 
     parserGenerate.add_argument(
-        "-s", "--shape", required=True,
-        help="Shape file defining the area to download.",
+        "-s",
+        "--shape",
+        required=True,
+        help=(
+            "Shape file (Shape.json, produced by create-bounds) defining the "
+            "area to download. The AOI center + view distance determine the "
+            "download bbox; the whole AOI must fit inside a single registered "
+            "imagery service."
+        ),
     )
     parserGenerate.add_argument(
-        "-o", "--output", default="output_tiles",
-        help="Directory to write the downloaded tile cache (default: "
-        "output_tiles).",
+        "-o",
+        "--output",
+        default="output_tiles",
+        help=(
+            "Directory to write the downloaded tile cache (default: "
+            "output_tiles). The gdal2tiles XYZ output can be imported with "
+            "`gather-ortho -src arcgis --from-download -i <this dir>`."
+        ),
     )
     parserGenerate.add_argument(
-        "--lod", type=int, required=True,
-        help="Zoom level to download and tile at (passed to gdal2tiles as -z).",
+        "--lod",
+        type=int,
+        required=True,
+        help=(
+            "Zoom level to download and tile at (passed to gdal2tiles as -z). "
+            "Must not be finer than the selected service's native resolution: "
+            "the service has no real detail below its native cell size, so a "
+            "finer LOD would only bake interpolated pixels into the cache."
+        ),
     )
     parserGenerate.add_argument(
-        "-w", "--workers", type=int, default=32,
-        help="Concurrent download threads (default: 32).",
+        "-w",
+        "--workers",
+        type=int,
+        default=32,
+        help=(
+            "Concurrent download threads (default: 32). Each thread fetches "
+            "exportImage chunks from the imagery service; failed chunks are "
+            "retried with backoff and re-fetched on a re-run."
+        ),
     )
     parserGenerate.add_argument(
-        "--chunk-px", type=int, default=256,
-        help="Pixels per exportImage request chunk (default: 256).",
+        "--chunk-px",
+        type=int,
+        default=256,
+        help=(
+            "Pixels per exportImage request chunk (default: 256). The AOI is "
+            "split into a grid of square chunks of this many pixels; larger "
+            "chunks mean fewer requests but larger responses."
+        ),
     )
     parserGenerate.add_argument(
-        "--timeout", type=int, default=30,
-        help="Per-request timeout in seconds (default: 30).",
+        "--timeout",
+        type=int,
+        default=30,
+        help=(
+            "Per-request timeout in seconds (default: 30). Transient HTTP "
+            "failures (429/5xx) are retried with exponential backoff up to 5 "
+            "attempts."
+        ),
     )
     parserGenerate.add_argument(
-        "--resampling", default="lanczos",
+        "--resampling",
+        default="lanczos",
         choices=["average", "near", "bilinear", "cubic", "cubicspline", "lanczos"],
-        help="gdal2tiles resampling (default: lanczos).",
+        help=(
+            "gdal2tiles resampling method, passed through as -r (default: "
+            "lanczos). Controls how the mosaic is resampled when producing "
+            "each zoom level's tiles."
+        ),
     )
     parserGenerate.add_argument(
-        "--processes", type=int, default=32,
-        help="Number of gdal2tiles tiling processes (default: 32).",
+        "--processes",
+        type=int,
+        default=32,
+        help=(
+            "Number of gdal2tiles tiling processes (default: 32). Passed to "
+            "gdal2tiles as --processes; more processes tile faster on "
+            "multi-core machines."
+        ),
     )
-    parserGenerate.add_argument("--xyz", dest="xyz", action="store_true", default=True)
-    parserGenerate.add_argument("--tms", dest="xyz", action="store_false")
+    parserGenerate.add_argument(
+        "--xyz",
+        dest="xyz",
+        action="store_true",
+        default=True,
+        help="Use XYZ (Google/OSM) tile numbering, y increasing southward (default).",
+    )
+    parserGenerate.add_argument(
+        "--tms",
+        dest="xyz",
+        action="store_false",
+        help="Use TMS tile numbering, y increasing northward (flipped).",
+    )
     parserGenerate.set_defaults(xyz=True)
+    parserGenerate.add_argument(
+        "--service-index",
+        type=int,
+        default=None,
+        help=(
+            "When several imagery services cover the AOI, pick one by its "
+            "0-based index in the printed candidate list. Only needed when "
+            "more than one registered service fully covers the AOI; run "
+            "without it to print the candidates and their native resolutions."
+        ),
+    )
+
+
+def addDownloadElevationArgs(subparser):
+    parserGenerate = subparser.add_parser(
+        "download-elevation",
+        help=(
+            "Download a continuous Float32 elevation GeoTIFF over the shape "
+            "AOI from a registered elevation ArcGIS service (e.g. USGS 3DEP)."
+        ),
+        description=(
+            "Download a continuous Float32 elevation GeoTIFF over the shape "
+            "AOI from a registered elevation ArcGIS service (e.g. USGS 3DEP). "
+            "The AOI is fetched as georeferenced F32 TIFF chunks, verified, "
+            "mosaicked, and written as a single merged GeoTIFF. Unlike "
+            "download-arcgis there is no gdal2tiles pass -- elevation is a "
+            "continuous raster, not a tile pyramid."
+        ),
+    )
+
+    parserGenerate.add_argument(
+        "-s",
+        "--shape",
+        required=True,
+        help=(
+            "Shape file (Shape.json, produced by create-bounds) defining the "
+            "area to download. The AOI center + view distance determine the "
+            "fetch bbox; the whole AOI must fit inside a single registered "
+            "elevation service."
+        ),
+    )
+    parserGenerate.add_argument(
+        "-o",
+        "--output",
+        default="elevation_merged.tif",
+        help=(
+            "Path to write the single merged elevation GeoTIFF (default: "
+            "elevation_merged.tif). The output is a Float32 continuous raster "
+            "in the service's SRS (Web Mercator), suitable for prep-geo / "
+            "gather-ortho -e consumption."
+        ),
+    )
+    parserGenerate.add_argument(
+        "--res",
+        type=float,
+        default=None,
+        help=(
+            "Fetch resolution in m/px (default: the service's registered "
+            "native pixel size). Requesting a finer resolution than native "
+            "prints a warning -- 3DEP resamples on the fly, so the extra "
+            "detail is interpolated, not real."
+        ),
+    )
+    parserGenerate.add_argument(
+        "--chunk-px",
+        type=int,
+        default=256,
+        help=(
+            "Pixels per exportImage request chunk (default: 256). The AOI is "
+            "split into a grid of square chunks of this many pixels; larger "
+            "chunks mean fewer requests but larger responses."
+        ),
+    )
+    parserGenerate.add_argument(
+        "--timeout",
+        type=int,
+        default=30,
+        help=(
+            "Per-request timeout in seconds (default: 30). Transient HTTP "
+            "failures (429/5xx) are retried with exponential backoff up to 5 "
+            "attempts."
+        ),
+    )
+    parserGenerate.add_argument(
+        "-w",
+        "--workers",
+        type=int,
+        default=32,
+        help=(
+            "Concurrent download threads (default: 32). Each thread fetches "
+            "exportImage chunks from the elevation service; failed chunks are "
+            "retried with backoff and re-fetched on a re-run."
+        ),
+    )
+    parserGenerate.add_argument(
+        "--service-index",
+        type=int,
+        default=None,
+        help=(
+            "When several elevation services cover the AOI, pick one by its "
+            "0-based index in the printed candidate list. Only needed when "
+            "more than one registered service fully covers the AOI; run "
+            "without it to print the candidates and their native resolutions."
+        ),
+    )
+    parserGenerate.add_argument(
+        "--padding",
+        type=float,
+        default=0.0,
+        help=(
+            "Degrees of padding added around the shape AOI when fetching "
+            "(default: 0). Expands the AOI bbox before projecting to Web "
+            "Mercator, so the merged GeoTIFF extends beyond the shape region."
+        ),
+    )
+
+
+def addRefreshServicesArgs(subparser):
+    parserGenerate = subparser.add_parser(
+        "refresh-services",
+        help=(
+            "Fetch metadata for each endpoint in the shipped scan list "
+            "(services_to_scan.json) and cache an imagery service registry "
+            "(coverage + native resolution per layer)."
+        ),
+        description=(
+            "Fetch metadata for each endpoint in the shipped scan list "
+            "(services_to_scan.json) and cache an imagery service registry "
+            "(coverage + native resolution per layer) in the user cache dir. "
+            "download-arcgis and download-elevation use this registry to "
+            "select the service covering an AOI. Run this once (or after "
+            "network changes) before the download commands."
+        ),
+    )
+    parserGenerate.add_argument(
+        "--from-file",
+        default=None,
+        help=(
+            "JSON file with an array of ImageServer endpoints to register "
+            "(URL strings, or {'url': ...} objects that may also declare "
+            "'pixel_size': <m/px> and 'kinds': ['imagery'|'elevation']) "
+            "instead of the shipped scan list. A top-level object with a "
+            "'folders' array is also accepted."
+        ),
+    )
+    parserGenerate.add_argument(
+        "--timeout",
+        type=int,
+        default=30,
+        help=(
+            "Per-request timeout in seconds (default: 30). Applied to each "
+            "endpoint's metadata request (f=json)."
+        ),
+    )
 
 
 def addPrepOrthoImages(subparser):
-    parserGenerate = subparser.add_parser("prep-ortho")
+    parserGenerate = subparser.add_parser(
+        "prep-ortho",
+        help=(
+            "Prepare gathered ortho zips into PNGs + height_info.json for "
+            "stitching"
+        ),
+        description=(
+            "Process the ortho zips gathered by `gather-ortho -src usgs` into "
+            "individual PNGs plus a height_info.json manifest. Each zip's "
+            "image is decoded in memory, optionally downscaled by "
+            "--scaleFactor, and written as <name>.png with its sidecar JSON. "
+            "Elevation files from -e are copied into the output and recorded "
+            "in the manifest under elevation_files."
+        ),
+    )
 
-    parserGenerate.add_argument("-o", "--output", help="Output directory")
-    parserGenerate.add_argument("-i", "--input", help="Input directory")
-    parserGenerate.add_argument("-f", "--scaleFactor", default=1.0, help="Scale amount")
+    parserGenerate.add_argument(
+        "-o",
+        "--output",
+        help=(
+            "Output directory for the prepared images. Receives one PNG + "
+            "sidecar JSON per input zip, a height_info.json manifest, any "
+            "elevation files copied from -e, and a copy of the shape file. "
+            "This directory is the -i input of stitch-ortho."
+        ),
+    )
+    parserGenerate.add_argument(
+        "-i",
+        "--input",
+        help=(
+            "Input directory containing the ortho zips + sidecar JSONs "
+            "produced by `gather-ortho -src usgs`."
+        ),
+    )
+    parserGenerate.add_argument(
+        "-f",
+        "--scaleFactor",
+        default=1.0,
+        help=(
+            "Scale amount: downscale factor applied to each image before "
+            "saving (default: 1.0 = no scaling). Resampling is LANCZOS; "
+            "values other than 1.0 reduce the output PNG dimensions by this "
+            "fraction."
+        ),
+    )
     parserGenerate.add_argument(
         "-e",
         "--elevationDataDir",
-        help="Directory containing elevation files to move into the output",
+        help=(
+            "Directory containing elevation files to move into the output. "
+            "Every .tif in this directory is copied into the output directory "
+            "and its basename is recorded in height_info.json under "
+            "'elevation_files' for downstream consumers."
+        ),
     )
-    parserGenerate.add_argument("-s", "--shapeFile")
+    parserGenerate.add_argument(
+        "-s",
+        "--shapeFile",
+        help=(
+            "Shape file (Shape.json) to copy into the output directory so "
+            "downstream stages (stitch-ortho, etc.) can consume it without "
+            "re-supplying the CLI argument. Required: the command fails if "
+            "the file does not exist."
+        ),
+    )
 
 
 def addStitchOrthoArgs(subparser):
-    parserGenerate = subparser.add_parser("stitch-ortho")
+    parserGenerate = subparser.add_parser(
+        "stitch-ortho",
+        help="Stitch prepared ortho PNGs into merged N x N group images",
+        description=(
+            "Stitch the prepared ortho PNGs from a prep-ortho output directory "
+            "into merged group images. Tiles are placed on their geographic "
+            "grid and partitioned into N x N windows (--dimension); each "
+            "window is composited into one gathered_r*_c*.png. Non-tile files "
+            "(elevation TIFs, Shape.json, sidecars) are passed through to the "
+            "output so it stays self-contained."
+        ),
+    )
 
     parserGenerate.add_argument(
         "-i",
         "--input",
         required=True,
-        help="prep-ortho output directory (PNGs + height_info.json)",
+        help=(
+            "prep-ortho output directory (PNGs + height_info.json). The "
+            "manifest's per-image bounds place each PNG on the tile grid; "
+            "elevation_files listed in the manifest are passed through to the "
+            "output."
+        ),
     )
     parserGenerate.add_argument(
         "-o",
         "--output",
         required=True,
-        help="Directory for stitched output",
+        help=(
+            "Directory for stitched output. Receives the merged "
+            "gathered_r*_c*.png images, a new height_info.json manifest, and "
+            "copies of every non-tile file from the input (elevation TIFs, "
+            "Shape.json, sidecars)."
+        ),
     )
     parserGenerate.add_argument(
         "-d",
         "--dimension",
         type=int,
         default=1,
-        help="Square side length to combine (2 = 2x2 -> 1 image). "
-        "1 = passthrough (default).",
+        help=(
+            "Square side length to combine (2 = 2x2 -> 1 image). "
+            "1 = passthrough (default). The tile grid is partitioned into "
+            "N x N windows; each window becomes one output image. Partial "
+            "edge windows and windows with holes produce smaller/ragged "
+            "images with absent cells left blank."
+        ),
     )
     parserGenerate.add_argument(
         "--skip-coverage-check",
         action="store_true",
         default=False,
-        help="Skip the tile coverage validation (touching/overlap checks). "
-        "By default the checks run.",
+        help=(
+            "Skip the tile coverage validation (touching/overlap checks). "
+            "By default the checks run: gaps/misalignment warn, and any "
+            "overlapping coverage aborts the stitch. Skipping can hide "
+            "missing coverage until the stitched output is inspected."
+        ),
     )
     parserGenerate.add_argument(
         "-f",
         "--scaleFactor",
         type=float,
         default=1.0,
-        help="Downscale each input tile by this fraction during stitching "
-        "(0.0 < value <= 1.0; 1.0 = no scaling). Only downscaling is supported.",
+        help=(
+            "Downscale each input tile by this fraction during stitching "
+            "(0.0 < value <= 1.0; 1.0 = no scaling). Only downscaling is "
+            "supported. Resampling is LANCZOS; for scale factors at or below "
+            "0.25, PIL's progressive reduction (reducing_gap) is used to "
+            "avoid moire and speed up large downscales."
+        ),
     )
     parserGenerate.add_argument(
         "--resume",
         action="store_true",
         default=False,
-        help="Skip groups whose stitched output already exists in the output "
-        "directory. Outputs are written atomically (temp-then-replace), so an "
-        "existing file is always a complete write from a prior run. Use this to "
-        "continue an interrupted stitch instead of re-doing finished groups.",
+        help=(
+            "Skip groups whose stitched output already exists in the output "
+            "directory. Outputs are written atomically (temp-then-replace), "
+            "so an existing file is always a complete write from a prior run. "
+            "Use this to continue an interrupted stitch instead of re-doing "
+            "finished groups."
+        ),
     )
 
     parserGenerate.add_argument(
@@ -236,48 +678,82 @@ def addStitchOrthoArgs(subparser):
         "--workers",
         type=int,
         default=None,
-        help="Number of worker processes for stitching (default: os.cpu_count). "
-        "Each worker holds one group's canvas in memory, so lower this if a "
-        "run exhausts memory at large canvases (e.g. scale_factor=1.0 with a "
-        "big --dimension).",
+        help=(
+            "Number of worker processes for stitching (default: os.cpu_count). "
+            "Each worker holds one group's canvas in memory, so lower this if "
+            "a run exhausts memory at large canvases (e.g. scale_factor=1.0 "
+            "with a big --dimension). Groups with >= 64 tiles are split into "
+            "row-strips fanned across the pool; giant canvases run as one "
+            "whole-group task at a time."
+        ),
     )
 
-
 def addPrepGeoArgs(subparser):
-    parserGenerate = subparser.add_parser("prep-geo")
+    parserGenerate = subparser.add_parser(
+        "prep-geo",
+        help="Merge elevation GeoTIFFs into one continuous raster",
+        description=(
+            "Merge a directory of elevation GeoTIFFs into a single continuous "
+            "raster clipped to a shape region. Tiles that do not overlap the "
+            "shape are ignored; the output is EPSG:4326 at the finest source "
+            "resolution, LZW-compressed, with NaN NoData for float rasters."
+        ),
+    )
 
     parserGenerate.add_argument(
         "-s",
         "--shape",
         required=True,
-        help="Shape file (Shape.json) defining the coverage region to merge "
-        "elevation GeoTIFFs for.",
+        help=(
+            "Shape file (Shape.json, produced by create-bounds) defining the "
+            "coverage region to merge elevation GeoTIFFs for. Tiles that do "
+            "not overlap this region are ignored; a warning is printed if the "
+            "available tiles do not fully cover it."
+        ),
     )
     parserGenerate.add_argument(
         "-i",
         "--input",
         required=True,
-        help="Directory of elevation GeoTIFFs (.tif) to merge.",
+        help=(
+            "Directory of elevation GeoTIFFs (.tif) to merge. Every .tif is "
+            "considered as a candidate tile; only those intersecting the shape "
+            "region are merged. Fails if the directory is empty or no tile "
+            "intersects the region."
+        ),
     )
     parserGenerate.add_argument(
         "-o",
         "--output",
         default="elevation_merged.tif",
-        help="Path for the merged continuous GeoTIFF (default: "
-        "elevation_merged.tif in the current directory).",
+        help=(
+            "Path for the merged continuous GeoTIFF (default: "
+            "elevation_merged.tif in the current directory). The output is "
+            "EPSG:4326 at the finest source resolution, LZW-compressed, with "
+            "NaN NoData for float rasters."
+        ),
     )
     parserGenerate.add_argument(
         "--padding",
         type=float,
         default=None,
-        help="Degrees of padding added around the shape region when clipping "
-        "(default: 0.1, ~1km at mid-latitudes).",
+        help=(
+            "Degrees of padding added around the shape region when clipping "
+            "(default: 0.1, ~1km at mid-latitudes). Keeps downstream consumers "
+            "from seeing NoData exactly at the region edge."
+        ),
     )
-
 
 def main():
     parser = argparse.ArgumentParser(
-        prog="TerrainStitcher", description="Entrypoint for terrain stitcher tools"
+        prog="TerrainStitcher",
+        description=(
+            "Entrypoint for terrain stitcher tools. Typical flow: "
+            "create-bounds -> gather-ortho (usgs) -> prep-ortho -> stitch-ortho, "
+            "or create-bounds -> download-arcgis -> gather-ortho -src arcgis "
+            "--from-download. Run refresh-services first to build the ArcGIS "
+            "service registry used by the download commands."
+        ),
     )
 
     subparser = parser.add_subparsers(dest="command")
@@ -285,6 +761,8 @@ def main():
     addCreateBoundsGeneratorArgs(subparser)
     addDownloadOrthoArgs(subparser)
     addDownloadArcgisArgs(subparser)
+    addDownloadElevationArgs(subparser)
+    addRefreshServicesArgs(subparser)
     addPrepOrthoImages(subparser)
     addStitchOrthoArgs(subparser)
     addPrepGeoArgs(subparser)
@@ -361,6 +839,21 @@ def main():
             chunk_px=args.chunk_px,
             processes=args.processes,
         )
+    elif args.command == "download-elevation":
+        main_elevation(
+            shape_file=args.shape,
+            outdir=args.output,
+            res=args.res,
+            timeout=args.timeout,
+            num_workers=args.workers,
+            chunk_px=args.chunk_px,
+            service_index=args.service_index,
+            padding=args.padding,
+        )
+    elif args.command == "refresh-services":
+        from terrain_stitcher.arcgis.services import refresh_services
+
+        refresh_services(timeout=args.timeout, from_file=args.from_file)
     elif args.command == "prep-ortho":
         # The elevation-prep stage moves every elevation file into the output
         # directory and returns the list of their filenames; record them in

--- a/src/terrain_stitcher/functions/DownloaderBase.py
+++ b/src/terrain_stitcher/functions/DownloaderBase.py
@@ -1,57 +1,30 @@
-import importlib
+from __future__ import annotations
+
+import json
 import math
 import shutil
 import subprocess
 import sys
 import time
-import json
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
-from tqdm import tqdm
 
 import requests
 from pyproj import Transformer
+from tqdm import tqdm
 
-from terrain_stitcher.common.ParseArea import ParseArea
-
-# --- Service-specific settings ---------------------------------------------
-# from alaska_vivid_2023_30cm ImageServer tileInfo
-
-BASE_URL = (
-    "https://apps.geo.fpac.usda.gov/nrcs-imagery/rest/services/"
-    "ortho_imagery/alaska_vivid_2023_30cm/ImageServer/exportImage"
+from terrain_stitcher.arcgis.services import (
+    AmbiguousServiceError,
+    ImageryService,
+    load_services,
+    select_service,
 )
-NATIVE_PIXEL_SIZE_M = 0.2985821417389697  # ~30cm, from the service's tileInfo
-SRS = 3857
-# ----------------------------------------------------------------------------
 
 WGS84_TO_WEBMERC = Transformer.from_crs("EPSG:4326", "EPSG:3857", always_xy=True)
 
 TRANSIENT_STATUS_CODES = {429, 500, 502, 503, 504}
 
-
-def pixel_size_for_zoom(zoom: int) -> float:
-    # standard web mercator resolution at zoom z, at the equator
-    earth_circumference_m = 2 * math.pi * 6378137.0
-    return earth_circumference_m / (256 * 2**zoom)
-
-
-def bbox_from_radius(lat: float, lon: float, radius_miles: float):
-    """Bounding box (xmin, ymin, xmax, ymax) in EPSG:3857 meters corresponding
-    to a real-world radius in miles around lat/lon."""
-    radius_m = radius_miles * 1609.344
-    meters_per_deg_lat = 111_320.0
-    meters_per_deg_lon = 111_320.0 * math.cos(math.radians(lat))
-
-    dlat = radius_m / meters_per_deg_lat
-    dlon = radius_m / meters_per_deg_lon
-
-    lat_min, lat_max = lat - dlat, lat + dlat
-    lon_min, lon_max = lon - dlon, lon + dlon
-
-    xmin, ymin = WGS84_TO_WEBMERC.transform(lon_min, lat_min)
-    xmax, ymax = WGS84_TO_WEBMERC.transform(lon_max, lat_max)
-    return xmin, ymin, xmax, ymax
+MANIFEST_FILENAME = "manifest.json"
 
 
 def build_chunk_grid(xmin, ymin, xmax, ymax, chunk_px: int, pixel_size_m: float):
@@ -98,18 +71,20 @@ def build_chunk_grid(xmin, ymin, xmax, ymax, chunk_px: int, pixel_size_m: float)
 
 def fetch_chunk(
     session: requests.Session,
+    service: ImageryService,
     chunk: dict,
     img_format: str,
     max_retries: int,
     timeout: int,
+    pixel_type: str = "U8",
 ) -> bytes:
     params = {
         "bbox": f"{chunk['xmin']},{chunk['ymin']},{chunk['xmax']},{chunk['ymax']}",
-        "bboxSR": SRS,
-        "imageSR": SRS,
+        "bboxSR": service.srs,
+        "imageSR": service.srs,
         "size": f"{chunk['w']},{chunk['h']}",
         "format": img_format,
-        "pixelType": "U8",
+        "pixelType": pixel_type,
         "interpolation": "RSP_BilinearInterpolation",
         "f": "image",
     }
@@ -117,7 +92,7 @@ def fetch_chunk(
     last_error = None
     for attempt in range(1, max_retries + 1):
         try:
-            resp = session.get(BASE_URL, params=params, timeout=timeout)
+            resp = session.get(service.base_url, params=params, timeout=timeout)
         except requests.RequestException as e:
             last_error = e
             time.sleep(min(2**attempt, 30))
@@ -144,10 +119,12 @@ def fetch_chunk(
     )
 
 
-def _georeference_inprocess(raw_path: Path, out_path: Path, chunk: dict) -> Path:
+def _georeference_inprocess(
+    raw_path: Path, out_path: Path, chunk: dict, srs: int
+) -> Path:
     """Georeference a raw image using the GDAL Python bindings.
 
-    Equivalent to ``gdal_translate -a_srs EPSG:{SRS} -a_ullr ...`` but runs
+    Equivalent to ``gdal_translate -a_srs EPSG:{srs} -a_ullr ...`` but runs
     in-process, avoiding the ~30-50 ms per-call subprocess-spawn overhead on
     Windows that dominates the cost for small chunks.
     """
@@ -156,7 +133,7 @@ def _georeference_inprocess(raw_path: Path, out_path: Path, chunk: dict) -> Path
     options = gdal.TranslateOptions(
         [
             "-a_srs",
-            f"EPSG:{SRS}",
+            f"EPSG:{srs}",
             "-a_ullr",
             str(chunk["xmin"]),
             str(chunk["ymax"]),
@@ -175,7 +152,9 @@ def _georeference_inprocess(raw_path: Path, out_path: Path, chunk: dict) -> Path
     return out_path
 
 
-def _georeference_subprocess(raw_path: Path, out_path: Path, chunk: dict) -> Path:
+def _georeference_subprocess(
+    raw_path: Path, out_path: Path, chunk: dict, srs: int
+) -> Path:
     """Georeference a raw image by shelling out to ``gdal_translate``.
 
     Fallback used when the GDAL Python bindings are not importable.
@@ -184,7 +163,7 @@ def _georeference_subprocess(raw_path: Path, out_path: Path, chunk: dict) -> Pat
         [
             "gdal_translate",
             "-a_srs",
-            f"EPSG:{SRS}",
+            f"EPSG:{srs}",
             "-a_ullr",
             str(chunk["xmin"]),
             str(chunk["ymax"]),
@@ -201,7 +180,7 @@ def _georeference_subprocess(raw_path: Path, out_path: Path, chunk: dict) -> Pat
 
 
 def georeference_chunk(
-    raw_bytes: bytes, chunk: dict, img_format: str, tmp_dir: Path
+    raw_bytes: bytes, chunk: dict, img_format: str, tmp_dir: Path, srs: int
 ) -> Path:
     ext = "tif" if img_format == "tiff" else img_format
     raw_path = tmp_dir / f"raw_{chunk['col']}_{chunk['row']}.{ext}"
@@ -209,15 +188,29 @@ def georeference_chunk(
 
     out_path = tmp_dir / f"chunk_{chunk['col']}_{chunk['row']}.tif"
     try:
-        _georeference_inprocess(raw_path, out_path, chunk)
+        _georeference_inprocess(raw_path, out_path, chunk, srs)
     except ImportError:
-        _georeference_subprocess(raw_path, out_path, chunk)
+        _georeference_subprocess(raw_path, out_path, chunk, srs)
     finally:
         raw_path.unlink(missing_ok=True)
     return out_path
 
 
-MANIFEST_FILENAME = "manifest.json"
+def write_chunk_direct(
+    raw_bytes: bytes, chunk: dict, img_format: str, tmp_dir: Path
+) -> Path:
+    """Persist an already-georeferenced exportImage response directly.
+
+    Used by the elevation path: ``format=tiff`` + ``pixelType=F32`` chunks
+    come back as fully georeferenced GeoTIFFs (they carry their own affine
+    transform + SRS), so unlike raw PNG ortho chunks they need no
+    ``-a_ullr`` / ``-a_srs`` pass. Writes ``chunk_{col}_{row}.tif`` to match
+    the filename convention the manifest and on-disk recovery expect.
+    """
+    ext = "tif" if img_format == "tiff" else img_format
+    out_path = tmp_dir / f"chunk_{chunk['col']}_{chunk['row']}.{ext}"
+    out_path.write_bytes(raw_bytes)
+    return out_path
 
 
 def _chunk_key(chunk: dict) -> str:
@@ -325,10 +318,24 @@ def _verify_chunk(path: Path) -> bool:
 
 
 def download_all_chunks(
-    chunks, img_format, max_retries, timeout, workers, tmp_dir: Path
+    chunks,
+    service: ImageryService,
+    img_format,
+    max_retries,
+    timeout,
+    workers,
+    tmp_dir: Path,
+    pixel_type: str = "U8",
+    georeference: bool = True,
 ) -> tuple[list[Path], list[dict]]:
     """Download *chunks* into *tmp_dir*, skipping any that already appear as
     downloaded in a previous run's manifest (and whose GeoTIFF still exists).
+
+    ``pixel_type`` selects the exportImage band depth (``U8`` for ortho PNGs,
+    ``F32`` for elevation). When ``georeference`` is True (ortho) raw bytes
+    are passed through :func:`georeference_chunk`; when False (elevation) the
+    already-georeferenced TIFF bytes are written directly via
+    :func:`write_chunk_direct`.
 
     Returns ``(chunk_paths, failed)`` where *chunk_paths* are the GeoTIFFs of
     every successfully fetched chunk (reused + freshly downloaded) and
@@ -413,7 +420,16 @@ def download_all_chunks(
 
     with requests.Session() as session, ThreadPoolExecutor(max_workers=workers) as pool:
         futures = {
-            pool.submit(fetch_chunk, session, c, img_format, max_retries, timeout): c
+            pool.submit(
+                fetch_chunk,
+                session,
+                service,
+                c,
+                img_format,
+                max_retries,
+                timeout,
+                pixel_type,
+            ): c
             for c in to_download
         }
 
@@ -423,7 +439,12 @@ def download_all_chunks(
                 key = _chunk_key(chunk)
                 try:
                     raw_bytes = future.result()
-                    path = georeference_chunk(raw_bytes, chunk, img_format, tmp_dir)
+                    if georeference:
+                        path = georeference_chunk(
+                            raw_bytes, chunk, img_format, tmp_dir, service.srs
+                        )
+                    else:
+                        path = write_chunk_direct(raw_bytes, chunk, img_format, tmp_dir)
                     chunk_paths.append(path)
                     manifest[key] = {"status": "downloaded", "file": path.name}
                     pbar.set_postfix_str(f"Chunk ({chunk['col']},{chunk['row']}) OK")
@@ -459,127 +480,106 @@ def build_mosaic(chunk_paths, tmp_dir: Path) -> Path:
     return vrt_path
 
 
-def run_gdal2tiles(
-    raster_path: Path,
-    outdir: str,
-    lod: str,
-    xyz: bool,
-    resampling: str,
-    processes: int,
-    webviewer: str,
-):
-    base_args = [
-        "-z",
-        str(lod),
-        "-w",
-        webviewer,
-        "-r",
-        resampling,
-        "--processes",
-        str(processes),
-    ]
-    if xyz:
-        base_args.append("--xyz")
-    base_args += [str(raster_path), outdir]
+def _translate_to_geotiff(vrt_path: Path, out_path: Path) -> Path:
+    """Burn a VRT into a single standalone GeoTIFF at *out_path*.
 
-    exe = shutil.which("gdal2tiles.py") or shutil.which("gdal2tiles")
-    if exe:
-        subprocess.run([exe, *base_args], check=True)
-        return
+    Tries the GDAL Python bindings first (in-process), falling back to the
+    ``gdal_translate`` command-line tool when they are not importable.
+    """
+    try:
+        from osgeo import gdal
 
-    for module_name in ("osgeo_utils.gdal2tiles", "gdal2tiles"):
+        ds = gdal.Translate(str(out_path), str(vrt_path), format="GTiff")
+        if ds is None:
+            raise RuntimeError(f"gdal.Translate failed for {vrt_path}")
+        ds = None
+        return Path(out_path)
+    except ImportError:
+        subprocess.run(
+            ["gdal_translate", str(vrt_path), str(out_path)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return Path(out_path)
+
+
+class ArcGISDownloaderBase:
+    """Shared plumbing for ArcGIS raster downloaders.
+
+    Subclasses (``OrthoDownloader``, ``ElevationDownloader``) set the
+    capability ``kind`` and the fetch parameters (image ``format``,
+    ``pixel_type``, and whether the raw exportImage bytes are already
+    georeferenced), then implement the rest of their pipeline (tiling vs.
+    merged-GeoTIFF). This class provides common service resolution and the
+    shared chunk-download/mosaic helpers.
+    """
+
+    kind = "imagery"
+    img_format = "png"
+    pixel_type = "U8"
+    georeference = True
+    tmp_dir_name = "aoi_chunks"
+    default_max_retries = 5
+
+    def __init__(
+        self,
+        service: ImageryService | None = None,
+        service_index: int | None = None,
+    ):
+        self.service = service
+        self.service_index = service_index
+
+    def resolve_service(self, loader, aoi_bbox) -> ImageryService:
+        """Pick a registered service of this downloader's ``kind`` for the AOI.
+
+        ``loader`` is a zero-arg callable returning the service registry
+        (usually :func:`terrain_stitcher.arcgis.services.load_services`).
+        When an explicit ``service`` was supplied to the constructor it is
+        returned unchanged. When several candidates cover the AOI and no
+        ``service_index`` disambiguates, the candidate list is printed and the
+        process exits (2).
+        """
+        if self.service is not None:
+            return self.service
         try:
-            importlib.import_module(module_name)
-        except ImportError:
-            continue
-        subprocess.run([sys.executable, "-m", module_name, *base_args], check=True)
-        return
+            service = select_service(
+                loader(), aoi_bbox, index=self.service_index, kind=self.kind
+            )
+        except AmbiguousServiceError as e:
+            print(
+                f"Multiple {self.kind} services cover this area. Re-run with "
+                "`--service-index <N>` to choose one:"
+            )
+            for i, s in enumerate(e.candidates):
+                print(
+                    f"  {i}: {s.label} ({s.key})  "
+                    f"native {s.native_pixel_size_m:.4f} m/px"
+                )
+            sys.exit(2)
+        print(f"Selected {self.kind} service: {service.label} ({service.key})")
+        return service
 
-    raise RuntimeError(
-        "Could not find gdal2tiles. Install with:\n"
-        "  conda install -c conda-forge gdal\n"
-        "  (or) pip install gdal2tiles-leaflet"
-    )
-
-
-def download_from_arcgis(
-    shapefile_path: str,
-    outdir,
-    zoom,
-    xyz,
-    resampling,
-    processes,
-    timeout,
-    num_workers,
-    chunk_px,
-):
-    shape_area = ParseArea.fromJSONFile(shapefile_path)
-
-    xmin, ymin, xmax, ymax = bbox_from_radius(
-        shape_area.center.get_lat(),
-        shape_area.center.get_lon(),
-        shape_area.view_distance,
-    )
-    print(f"AOI bbox (EPSG:3857): {xmin:.1f}, {ymin:.1f}, {xmax:.1f}, {ymax:.1f}")
-
-    tmp_dir = Path("aoi_chunks")
-    tmp_dir.mkdir(exist_ok=True)
-
-    pixel_size_m = max(NATIVE_PIXEL_SIZE_M, pixel_size_for_zoom(zoom))
-
-    chunks = build_chunk_grid(xmin, ymin, xmax, ymax, chunk_px, pixel_size_m)
-
-    print(f"Downloading {len(chunks)} chunks with {num_workers} workers...")
-    chunk_paths, failed = download_all_chunks(
-        chunks, "png", 5, timeout, num_workers, tmp_dir
-    )
-
-    if not chunk_paths:
-        print("No chunks downloaded successfully - aborting.")
-        sys.exit(1)
-
-    print("Building mosaic...")
-    mosaic_path = build_mosaic(chunk_paths, tmp_dir)
-
-    print(f"Tiling (zoom {zoom})...")
-    run_gdal2tiles(mosaic_path, outdir, zoom, xyz, resampling, processes, "none")
-
-    if failed:
-        print(
-            f"\nCompleted with {len(failed)} failed chunk(s). "
-            f"Tiles written to: {outdir} ({'XYZ' if xyz else 'TMS'} numbering), "
-            f"but gaps exist where chunks failed.\n"
-            f"Temporary chunk files kept in {tmp_dir} -- re-run the same "
-            f"command to retry only the {len(failed)} failed chunk(s)."
+    def download_chunks(
+        self,
+        service: ImageryService,
+        chunks,
+        tmp_dir: Path,
+        timeout: int,
+        num_workers: int,
+        max_retries: int | None = None,
+    ) -> tuple[list[Path], list[dict]]:
+        """Download *chunks* for *service* into *tmp_dir* using this
+        downloader's ``img_format`` / ``pixel_type`` / ``georeference``."""
+        max_retries = self.default_max_retries if max_retries is None else max_retries
+        return download_all_chunks(
+            chunks,
+            service,
+            self.img_format,
+            max_retries,
+            timeout,
+            num_workers,
+            tmp_dir,
+            pixel_type=self.pixel_type,
+            georeference=self.georeference,
         )
-    else:
-        # all chunks succeeded -- safe to clean up temporary files
-        shutil.rmtree(tmp_dir, ignore_errors=True)
-        print(
-            f"Done. Tiles written to: {outdir} "
-            f"({'XYZ' if xyz else 'TMS'} numbering)"
-        )
-
-
-def main(
-    shape_file,
-    lod: int,
-    outdir="output_tiles",
-    xyz: bool = True,
-    resampling: str = "lanczos",
-    processes: int = 32,
-    timeout: int = 30,
-    num_workers: int = 32,
-    chunk_px: int = 256,
-):
-    download_from_arcgis(
-        shapefile_path=shape_file,
-        outdir=outdir,
-        zoom=lod,
-        xyz=xyz,
-        resampling=resampling,
-        processes=processes,
-        timeout=timeout,
-        num_workers=num_workers,
-        chunk_px=chunk_px,
-    )

--- a/src/terrain_stitcher/functions/ElevationDownloader.py
+++ b/src/terrain_stitcher/functions/ElevationDownloader.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+from terrain_stitcher.arcgis.services import (
+    ImageryService,
+    bbox_latlon_from_radius,
+    load_services,
+)
+from terrain_stitcher.common.ParseArea import ParseArea
+
+from .DownloaderBase import (
+    ArcGISDownloaderBase,
+    WGS84_TO_WEBMERC,
+    build_chunk_grid,
+    build_mosaic,
+    _translate_to_geotiff,
+)
+
+
+class ElevationDownloader(ArcGISDownloaderBase):
+    """Downloads a continuous Float32 elevation GeoTIFF over a shape AOI.
+
+    Selects an ``"elevation"`` ArcGIS service (e.g. USGS 3DEPElevation),
+    requests ``format=tiff`` + ``pixelType=F32`` chunks at ``res`` m/px,
+    verifies + mosaics them, and writes the single merged GeoTIFF to *outdir*.
+    Unlike orthoimagery there is no gdal2tiles pass -- elevation is a
+    continuous raster, not a tile pyramid.
+    """
+
+    kind = "elevation"
+    img_format = "tiff"
+    pixel_type = "F32"
+    georeference = False
+    tmp_dir_name = "aoi_chunks_elevation"
+    default_outdir = "elevation_merged.tif"
+
+    def run(
+        self,
+        shapefile_path: str,
+        outdir: str,
+        res: float | None = None,
+        chunk_px: int = 256,
+        timeout: int = 30,
+        num_workers: int = 32,
+        padding: float = 0.0,
+    ) -> None:
+        shape_area = ParseArea.fromJSONFile(shapefile_path)
+        lat = shape_area.center.get_lat()
+        lon = shape_area.center.get_lon()
+
+        # Resolve the elevation service from the AOI when one is not supplied.
+        aoi_bbox = bbox_latlon_from_radius(lat, lon, shape_area.view_distance)
+        service = self.resolve_service(load_services, aoi_bbox)
+
+        # Default resolution to the service's registered native cell size.
+        pixel_size_m = res if res is not None else service.native_pixel_size_m
+        if pixel_size_m <= 0:
+            raise ValueError(
+                f"{service.key} has an invalid native pixel size; pass --res."
+            )
+        if res is not None and res < service.native_pixel_size_m:
+            # 3DEP resamples on the fly; warn rather than fail so a user can
+            # still request a slightly finer grid than the declared cell size.
+            print(
+                f"Warning: requested {res:.4f} m/px is finer than {service.key}'s "
+                f"declared native resolution {service.native_pixel_size_m:.4f} "
+                f"m/px; 3DEP will resample on the fly."
+            )
+
+        # Expand the AOI by an optional padding (degrees) before projecting.
+        min_lat, min_lon, max_lat, max_lon = aoi_bbox
+        if padding:
+            min_lat -= padding
+            min_lon -= padding
+            max_lat += padding
+            max_lon += padding
+        xmin, ymin = WGS84_TO_WEBMERC.transform(min_lon, min_lat)
+        xmax, ymax = WGS84_TO_WEBMERC.transform(max_lon, max_lat)
+        print(f"AOI bbox (EPSG:3857): {xmin:.1f}, {ymin:.1f}, {xmax:.1f}, {ymax:.1f}")
+
+        tmp_dir = Path(outdir).parent / self.tmp_dir_name
+        tmp_dir.mkdir(exist_ok=True)
+
+        chunks = build_chunk_grid(xmin, ymin, xmax, ymax, chunk_px, pixel_size_m)
+
+        # Elevation chunks are already-georeferenced F32 TIFFs, so we skip the
+        # georeference pass and write the bytes straight to disk.
+        chunk_paths, failed = self.download_chunks(
+            service, chunks, tmp_dir, timeout, num_workers
+        )
+
+        if not chunk_paths:
+            print("No elevation chunks downloaded successfully - aborting.")
+            sys.exit(1)
+
+        print("Building mosaic...")
+        mosaic_path = build_mosaic(chunk_paths, tmp_dir)
+
+        print(f"Writing merged GeoTIFF -> {outdir}")
+        _translate_to_geotiff(mosaic_path, Path(outdir))
+
+        if failed:
+            print(
+                f"\nCompleted with {len(failed)} failed chunk(s); "
+                f"gaps exist where chunks failed.\n"
+                f"Temporary chunk files kept in {tmp_dir} -- re-run the same "
+                f"command to retry only the {len(failed)} failed chunk(s)."
+            )
+        else:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+            print(f"Done. Merged elevation GeoTIFF written to: {outdir}")
+
+
+def download_elevation(
+    shapefile_path: str,
+    outdir: str = "elevation_merged.tif",
+    res: float | None = None,
+    chunk_px: int = 256,
+    timeout: int = 30,
+    num_workers: int = 32,
+    service: ImageryService | None = None,
+    service_index: int | None = None,
+    padding: float = 0.0,
+):
+    """Fetch a continuous Float32 elevation GeoTIFF over the shape AOI.
+
+    Selects an ``"elevation"`` ArcGIS service (e.g. USGS 3DEPElevation),
+    requests ``format=tiff`` + ``pixelType=F32`` chunks at ``res`` m/px,
+    verifies + mosaics them, and writes the single merged GeoTIFF to
+    *outdir*. ``res`` defaults to the selected service's registered native
+    pixel size.
+    """
+    ElevationDownloader(service=service, service_index=service_index).run(
+        shapefile_path=shapefile_path,
+        outdir=outdir,
+        res=res,
+        chunk_px=chunk_px,
+        timeout=timeout,
+        num_workers=num_workers,
+        padding=padding,
+    )
+
+
+def main_elevation(
+    shape_file,
+    outdir="elevation_merged.tif",
+    res: float | None = None,
+    timeout: int = 30,
+    num_workers: int = 32,
+    chunk_px: int = 256,
+    service: ImageryService | None = None,
+    service_index: int | None = None,
+    padding: float = 0.0,
+):
+    download_elevation(
+        shapefile_path=shape_file,
+        outdir=outdir,
+        res=res,
+        chunk_px=chunk_px,
+        timeout=timeout,
+        num_workers=num_workers,
+        service=service,
+        service_index=service_index,
+        padding=padding,
+    )

--- a/src/terrain_stitcher/functions/OrthoDownloader.py
+++ b/src/terrain_stitcher/functions/OrthoDownloader.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+import importlib
+import math
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from terrain_stitcher.arcgis.services import (
+    ImageryService,
+    bbox_latlon_from_radius,
+    load_services,
+)
+from terrain_stitcher.common.ParseArea import ParseArea
+
+from .DownloaderBase import (
+    ArcGISDownloaderBase,
+    WGS84_TO_WEBMERC,
+    build_chunk_grid,
+    build_mosaic,
+)
+
+
+def pixel_size_for_zoom(zoom: int) -> float:
+    # standard web mercator resolution at zoom z, at the equator
+    earth_circumference_m = 2 * math.pi * 6378137.0
+    return earth_circumference_m / (256 * 2**zoom)
+
+
+def assert_lod_within_native(zoom: int, service: ImageryService) -> None:
+    """Raise ``ValueError`` if ``zoom`` implies a finer resolution than
+    the service's native cell size.
+
+    The source cannot produce real detail below its native cell size, so
+    fetching at a finer LOD would only bake interpolated pixels into the
+    cache via gdal2tiles upscaling. There is deliberately no override:
+    request a lower LOD instead.
+    """
+    zoom_res = pixel_size_for_zoom(zoom)
+    if zoom_res < service.native_pixel_size_m:
+        raise ValueError(
+            f"LOD {zoom} implies {zoom_res:.4f} m/px, but {service.key} "
+            f"native resolution is {service.native_pixel_size_m:.4f} m/px "
+            f"(~LOD {round(math.log2(156543.0339 / service.native_pixel_size_m), 1)}). "
+            f"Request a lower LOD; the service has no real detail below "
+            f"its native cell size."
+        )
+
+
+def bbox_from_radius(lat: float, lon: float, radius_miles: float):
+    """Bounding box (xmin, ymin, xmax, ymax) in EPSG:3857 meters corresponding
+    to a real-world radius in miles around lat/lon."""
+    radius_m = radius_miles * 1609.344
+    meters_per_deg_lat = 111_320.0
+    meters_per_deg_lon = 111_320.0 * math.cos(math.radians(lat))
+
+    dlat = radius_m / meters_per_deg_lat
+    dlon = radius_m / meters_per_deg_lon
+
+    lat_min, lat_max = lat - dlat, lat + dlat
+    lon_min, lon_max = lon - dlon, lon + dlon
+
+    xmin, ymin = WGS84_TO_WEBMERC.transform(lon_min, lat_min)
+    xmax, ymax = WGS84_TO_WEBMERC.transform(lon_max, lat_max)
+    return xmin, ymin, xmax, ymax
+
+
+def run_gdal2tiles(
+    raster_path: Path,
+    outdir: str,
+    lod: str,
+    xyz: bool,
+    resampling: str,
+    processes: int,
+    webviewer: str,
+):
+    base_args = [
+        "-z",
+        str(lod),
+        "-w",
+        webviewer,
+        "-r",
+        resampling,
+        "--processes",
+        str(processes),
+    ]
+    if xyz:
+        base_args.append("--xyz")
+    base_args += [str(raster_path), outdir]
+
+    exe = shutil.which("gdal2tiles.py") or shutil.which("gdal2tiles")
+    if exe:
+        subprocess.run([exe, *base_args], check=True)
+        return
+
+    for module_name in ("osgeo_utils.gdal2tiles", "gdal2tiles"):
+        try:
+            importlib.import_module(module_name)
+        except ImportError:
+            continue
+        subprocess.run([sys.executable, "-m", module_name, *base_args], check=True)
+        return
+
+    raise RuntimeError(
+        "Could not find gdal2tiles. Install with:\n"
+        "  conda install -c conda-forge gdal\n"
+        "  (or) pip install gdal2tiles-leaflet"
+    )
+
+
+class OrthoDownloader(ArcGISDownloaderBase):
+    """Downloads orthoimagery over a shape AOI as PNG chunks and tiles them
+    with gdal2tiles into a web-mercator tile cache."""
+
+    kind = "imagery"
+    img_format = "png"
+    pixel_type = "U8"
+    georeference = True
+    tmp_dir_name = "aoi_chunks"
+    default_outdir = "output_tiles"
+
+    def run(
+        self,
+        shapefile_path: str,
+        outdir: str,
+        zoom: int,
+        xyz: bool,
+        resampling: str,
+        processes: int,
+        timeout: int,
+        num_workers: int,
+        chunk_px: int,
+    ) -> None:
+        shape_area = ParseArea.fromJSONFile(shapefile_path)
+        lat = shape_area.center.get_lat()
+        lon = shape_area.center.get_lon()
+
+        # Resolve the imagery service from the AOI when one is not supplied.
+        # The service's WGS84 coverage bbox picks the right state layer and
+        # validates that the whole AOI fits inside it (downloads are limited
+        # to one state).
+        aoi_bbox = bbox_latlon_from_radius(lat, lon, shape_area.view_distance)
+        service = self.resolve_service(load_services, aoi_bbox)
+
+        # Fail (no override) when the requested LOD is finer than the
+        # service's native cell size -- see assert_lod_within_native.
+        assert_lod_within_native(zoom, service)
+
+        xmin, ymin, xmax, ymax = bbox_from_radius(
+            lat,
+            lon,
+            shape_area.view_distance,
+        )
+        print(f"AOI bbox (EPSG:3857): {xmin:.1f}, {ymin:.1f}, {xmax:.1f}, {ymax:.1f}")
+
+        tmp_dir = Path("aoi_chunks")
+        tmp_dir.mkdir(exist_ok=True)
+
+        pixel_size_m = pixel_size_for_zoom(zoom)
+
+        chunks = build_chunk_grid(xmin, ymin, xmax, ymax, chunk_px, pixel_size_m)
+
+        print(f"Downloading {len(chunks)} chunks with {num_workers} workers...")
+        chunk_paths, failed = self.download_chunks(
+            service, chunks, tmp_dir, timeout, num_workers
+        )
+
+        if not chunk_paths:
+            print("No chunks downloaded successfully - aborting.")
+            sys.exit(1)
+
+        print("Building mosaic...")
+        mosaic_path = build_mosaic(chunk_paths, tmp_dir)
+
+        print(f"Tiling (zoom {zoom})...")
+        run_gdal2tiles(mosaic_path, outdir, zoom, xyz, resampling, processes, "none")
+
+        if failed:
+            print(
+                f"\nCompleted with {len(failed)} failed chunk(s). "
+                f"Tiles written to: {outdir} ({'XYZ' if xyz else 'TMS'} numbering), "
+                f"but gaps exist where chunks failed.\n"
+                f"Temporary chunk files kept in {tmp_dir} -- re-run the same "
+                f"command to retry only the {len(failed)} failed chunk(s)."
+            )
+        else:
+            # all chunks succeeded -- safe to clean up temporary files
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+            print(
+                f"Done. Tiles written to: {outdir} "
+                f"({'XYZ' if xyz else 'TMS'} numbering)"
+            )
+
+
+def download_from_arcgis(
+    shapefile_path: str,
+    outdir,
+    zoom,
+    xyz,
+    resampling,
+    processes,
+    timeout,
+    num_workers,
+    chunk_px,
+    service: ImageryService | None = None,
+    service_index: int | None = None,
+):
+    OrthoDownloader(service=service, service_index=service_index).run(
+        shapefile_path=shapefile_path,
+        outdir=outdir,
+        zoom=zoom,
+        xyz=xyz,
+        resampling=resampling,
+        processes=processes,
+        timeout=timeout,
+        num_workers=num_workers,
+        chunk_px=chunk_px,
+    )
+
+
+def main(
+    shape_file,
+    lod: int,
+    outdir="output_tiles",
+    xyz: bool = True,
+    resampling: str = "lanczos",
+    processes: int = 32,
+    timeout: int = 30,
+    num_workers: int = 32,
+    chunk_px: int = 256,
+    service: ImageryService | None = None,
+    service_index: int | None = None,
+):
+    download_from_arcgis(
+        shapefile_path=shape_file,
+        outdir=outdir,
+        zoom=lod,
+        xyz=xyz,
+        resampling=resampling,
+        processes=processes,
+        timeout=timeout,
+        num_workers=num_workers,
+        chunk_px=chunk_px,
+        service=service,
+        service_index=service_index,
+    )

--- a/src/terrain_stitcher/functions/__init__.py
+++ b/src/terrain_stitcher/functions/__init__.py
@@ -2,8 +2,11 @@ from .OrthoScraper import main as main_ortho
 from .ShapeGenerator import main as main_shape
 from .OrthoPrep import main as main_prep_ortho
 from .ArcGisImporter import import_from_arcgis_dir as main_ortho_arcgis_import
-from .ArcGisImporter import import_from_download as main_ortho_arcgis_import_from_download
+from .ArcGisImporter import (
+    import_from_download as main_ortho_arcgis_import_from_download,
+)
 from .ElevationTIFPrep import main as main_prep_elevation
 from .ElevationGeoPrep import main as main_prep_geo
 from .OrthoStitcher import main as main_stitch_ortho
-from .ArcGisDownloader import main as main_arcgis_downloader
+from .OrthoDownloader import main as main_arcgis_downloader
+from .ElevationDownloader import main_elevation

--- a/tests/test_download_elevation.py
+++ b/tests/test_download_elevation.py
@@ -1,0 +1,212 @@
+import json
+
+import pytest
+
+from terrain_stitcher.arcgis.services import ImageryService
+from terrain_stitcher.functions import (
+    DownloaderBase,
+    ElevationDownloader,
+    OrthoDownloader,
+)
+import requests
+
+
+def _elev_service(key="3dep", kinds=("elevation",)):
+    return ImageryService(
+        key=key,
+        label=key,
+        base_url=f"https://example/{key}/ImageServer/exportImage",
+        native_pixel_size_m=10.0,
+        srs=3857,
+        coverage=(10.0, -100.0, 60.0, -50.0),
+        kinds=list(kinds),
+    )
+
+
+def _shape(tmp_path, lon=-90.0, lat=40.0, radius=5.0):
+    p = tmp_path / "Shape.json"
+    p.write_text(
+        json.dumps(
+            {
+                "boundsType": "POINT",
+                "center": {"x": lon, "y": lat},
+                "view_distance": radius,
+            }
+        )
+    )
+    return p
+
+
+class _FakeResp:
+    status_code = 200
+    headers = {"Content-Type": "image/tiff"}
+    content = b"II*\x00\x08\x00\x00\x00"
+    text = ""
+
+
+class _FakeSession:
+    def __init__(self):
+        self.calls = []
+
+    def get(self, url, params=None, timeout=None):
+        self.calls.append(dict(params))
+        return _FakeResp()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def test_download_elevation_fetches_f32_tiff(monkeypatch, tmp_path):
+    """download_elevation must request format=tiff + pixelType=F32, write the
+    already-georeferenced chunk TIFFs directly (no georeference pass), and
+    produce the merged GeoTIFF via build_mosaic."""
+    service = _elev_service()
+    monkeypatch.setattr(ElevationDownloader, "load_services", lambda: {"3dep": service})
+
+    fake = _FakeSession()
+    monkeypatch.setattr(requests, "Session", lambda: fake)
+
+    # Guard: the direct-write path must NOT run a georeference pass.
+    def _boom(*a, **k):
+        raise AssertionError("georeference_chunk should not be called for elevation")
+
+    monkeypatch.setattr(DownloaderBase, "georeference_chunk", _boom)
+
+    out = tmp_path / "elevation_merged.tif"
+
+    calls = []
+
+    def fake_build_mosaic(chunk_paths, td):
+        calls.append(("build_mosaic", len(chunk_paths)))
+        vrt = td / "mosaic.vrt"
+        vrt.write_text("vrt")
+        return vrt
+
+    monkeypatch.setattr(ElevationDownloader, "build_mosaic", fake_build_mosaic)
+
+    def fake_translate(vrt, out_path):
+        calls.append(("translate", str(out_path)))
+        out_path.write_bytes(b"geotiff")
+        return out_path
+
+    monkeypatch.setattr(ElevationDownloader, "_translate_to_geotiff", fake_translate)
+
+    ElevationDownloader.download_elevation(
+        shapefile_path=str(_shape(tmp_path)),
+        outdir=str(out),
+        res=30.0,
+        num_workers=1,
+    )
+
+    assert out.is_file()
+    assert fake.calls, "no exportImage requests were made"
+    for params in fake.calls:
+        assert params["format"] == "tiff"
+        assert params["pixelType"] == "F32"
+    # At least one chunk was written directly and mosaicked.
+    mosaic_calls = [c for c in calls if c[0] == "build_mosaic"]
+    assert mosaic_calls and mosaic_calls[0][1] >= 1
+    assert ("translate", str(out)) in calls
+
+
+def test_download_elevation_default_res_uses_service_native(monkeypatch, tmp_path):
+    """With no --res, the chunk grid resolution defaults to the service's
+    registered native pixel size."""
+    service = _elev_service()
+    monkeypatch.setattr(ElevationDownloader, "load_services", lambda: {"3dep": service})
+    fake = _FakeSession()
+    monkeypatch.setattr(requests, "Session", lambda: fake)
+
+    # Capture the resolution passed to build_chunk_grid.
+    captured = {}
+
+    def fake_grid(xmin, ymin, xmax, ymax, chunk_px, pixel_size_m):
+        captured["res"] = pixel_size_m
+        # single 1x1 chunk
+        return [
+            {
+                "row": 0,
+                "col": 0,
+                "w": 1,
+                "h": 1,
+                "xmin": xmin,
+                "ymin": ymin,
+                "xmax": xmin + pixel_size_m,
+                "ymax": ymin + pixel_size_m,
+            }
+        ]
+
+    monkeypatch.setattr(ElevationDownloader, "build_chunk_grid", fake_grid)
+
+    def fake_mosaic(chunk_paths, td):
+        vrt = td / "mosaic.vrt"
+        vrt.write_text("vrt")
+        return vrt
+
+    monkeypatch.setattr(ElevationDownloader, "build_mosaic", fake_mosaic)
+    monkeypatch.setattr(
+        ElevationDownloader,
+        "_translate_to_geotiff",
+        lambda v, o: o.write_bytes(b"x") or o,
+    )
+
+    out = tmp_path / "elevation_merged.tif"
+    ElevationDownloader.download_elevation(
+        shapefile_path=str(_shape(tmp_path)), outdir=str(out), num_workers=1
+    )
+    assert captured["res"] == 10.0
+
+
+def test_download_elevation_ambiguous_prints_list_and_exits(
+    monkeypatch, tmp_path, capsys
+):
+    """Multiple covering elevation services with no --service-index prints the
+    candidate list and exits 2 (no network)."""
+    monkeypatch.setattr(
+        ElevationDownloader,
+        "load_services",
+        lambda: {"a": _elev_service("a"), "b": _elev_service("b")},
+    )
+
+    def _boom(*a, **k):
+        raise AssertionError("network call attempted")
+
+    monkeypatch.setattr(requests, "Session", _boom)
+
+    with pytest.raises(SystemExit) as ei:
+        ElevationDownloader.download_elevation(
+            shapefile_path=str(_shape(tmp_path)),
+            outdir=str(tmp_path / "elevation_merged.tif"),
+            num_workers=1,
+        )
+    assert ei.value.code == 2
+    out = capsys.readouterr().out
+    assert "--service-index" in out
+    assert "a" in out and "b" in out
+
+
+def test_download_arcgis_selects_imagery_not_elevation(monkeypatch, tmp_path, capsys):
+    """download_from_arcgis must resolve an imagery service and never pick an
+    elevation-only service -- even when it is the only covering layer."""
+    # Only an elevation service covers this AOI.
+    monkeypatch.setattr(
+        ElevationDownloader, "load_services", lambda: {"dem": _elev_service("dem")}
+    )
+
+    with pytest.raises(ValueError) as ei:
+        OrthoDownloader.download_from_arcgis(
+            shapefile_path=str(_shape(tmp_path)),
+            outdir=str(tmp_path / "out"),
+            zoom=15,
+            xyz=True,
+            resampling="lanczos",
+            processes=1,
+            timeout=30,
+            num_workers=1,
+            chunk_px=256,
+        )
+    assert "imagery" in str(ei.value)
+    assert "elevation" not in str(ei.value)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,345 @@
+import json
+
+import pytest
+
+from terrain_stitcher.arcgis import services as services_mod
+from terrain_stitcher.arcgis.services import (
+    ImageryService,
+    bbox_latlon_from_radius,
+    load_services,
+    select_service,
+)
+
+ALASKA = ImageryService(
+    key="alaska_vivid_2023_30cm",
+    label="Alaska Vivid 2023 30cm",
+    base_url=(
+        "https://apps.geo.fpac.usda.gov/nrcs-imagery/rest/services/"
+        "ortho_imagery/alaska_vivid_2023_30cm/ImageServer/exportImage"
+    ),
+    native_pixel_size_m=0.2985821417389697,
+    srs=3857,
+    coverage=(51.0, -180.0, 71.5, -129.0),
+)
+
+
+@pytest.fixture()
+def services():
+    return {"alaska_vivid_2023_30cm": ALASKA}
+
+
+def test_select_service_for_in_state_aoi(services):
+    aoi = bbox_latlon_from_radius(61.0, -149.0, 5.0)
+    svc = select_service(services, aoi)
+    assert svc.key == "alaska_vivid_2023_30cm"
+
+
+def test_select_service_rejects_out_of_coverage_center(services):
+    # Maine is nowhere near the Alaska layer.
+    aoi = bbox_latlon_from_radius(44.3, -68.2, 5.0)
+    with pytest.raises(ValueError, match="not inside any registered"):
+        select_service(services, aoi)
+
+
+def test_select_service_rejects_aoi_straddling_coverage(services):
+    # Center is inside Alaska, but the radius is huge so the AOI bbox pokes
+    # outside the layer footprint -- downloads are limited to one state.
+    aoi = bbox_latlon_from_radius(61.0, -149.0, 800.0)
+    with pytest.raises(ValueError, match="extends outside"):
+        select_service(services, aoi)
+
+
+def test_select_service_empty_cache_directs_to_refresh():
+    with pytest.raises(ValueError, match="refresh-services"):
+        select_service({}, bbox_latlon_from_radius(61.0, -149.0, 5.0))
+
+
+def test_load_services_empty_without_cache(monkeypatch):
+    monkeypatch.setattr(services_mod, "_cache_path", lambda: None)
+    assert load_services() == {}
+
+
+def test_load_services_reads_cache(monkeypatch, tmp_path):
+    cache = tmp_path / "services.json"
+    cache.write_text(json.dumps({"services": [ALASKA.to_dict()]}))
+    monkeypatch.setattr(services_mod, "_cache_path", lambda: cache)
+    loaded = load_services()
+    assert set(loaded) == {"alaska_vivid_2023_30cm"}
+    assert loaded["alaska_vivid_2023_30cm"].coverage == ALASKA.coverage
+
+
+def test_shipped_scan_list_is_present():
+    items = services_mod._shipped_scan_items()
+    assert isinstance(items, list) and len(items) >= 1
+
+
+def test_imagery_service_roundtrip():
+    svc = ImageryService(
+        key="x",
+        label="X",
+        base_url="http://example/x/ImageServer/exportImage",
+        native_pixel_size_m=0.5,
+        srs=3857,
+        coverage=(10.0, -100.0, 20.0, -90.0),
+    )
+    d = svc.to_dict()
+    assert d["coverage"] == [10.0, -100.0, 20.0, -90.0]
+    assert ImageryService.from_dict(d) == svc
+    assert svc.contains_point(15.0, -95.0)
+    assert not svc.contains_point(25.0, -95.0)
+    assert svc.contains_bbox((12.0, -98.0, 18.0, -92.0))
+    assert not svc.contains_bbox((12.0, -110.0, 18.0, -92.0))
+
+
+# --- LOD vs native resolution guard -----------------------------------------
+
+
+def test_assert_lod_within_native_rejects_finer_lod():
+    from terrain_stitcher.functions.OrthoDownloader import assert_lod_within_native
+
+    # Alaska native ~0.2986 m/px == ~LOD 19; LOD 23 is finer.
+    import pytest
+
+    with pytest.raises(ValueError, match="native resolution"):
+        assert_lod_within_native(23, ALASKA)
+
+
+def test_assert_lod_within_native_allows_coarser_and_equal_lod():
+    from terrain_stitcher.functions.OrthoDownloader import assert_lod_within_native
+
+    # Coarser than native (LOD 17 -> 1.19 m/px) and equal (LOD 19 -> native)
+    # must not raise.
+    assert assert_lod_within_native(17, ALASKA) is None
+    assert assert_lod_within_native(19, ALASKA) is None
+
+
+def test_download_arcgis_rejects_lod_above_native(monkeypatch, tmp_path):
+    """download_from_arcgis must fail fast (before any network/disk) when the
+    requested LOD is finer than the service native resolution."""
+    import json as _json
+    import pytest
+    from terrain_stitcher.functions.OrthoDownloader import download_from_arcgis
+
+    shape = tmp_path / "Shape.json"
+    shape.write_text(
+        _json.dumps(
+            {
+                "boundsType": "POINT",
+                "center": {"x": -149.0, "y": 61.0},
+                "view_distance": 5.0,
+            }
+        )
+    )
+    # If the guard fails to fire, the next steps hit the network / disk;
+    # fail the test loudly if any request is attempted.
+    import requests as _requests
+
+    def _boom(*a, **k):
+        raise AssertionError("network call attempted before the LOD guard")
+
+    monkeypatch.setattr(_requests, "get", _boom)
+
+    with pytest.raises(ValueError, match="native resolution"):
+        download_from_arcgis(
+            shapefile_path=str(shape),
+            outdir=str(tmp_path / "out"),
+            zoom=23,
+            xyz=True,
+            resampling="lanczos",
+            processes=1,
+            timeout=30,
+            num_workers=1,
+            chunk_px=256,
+            service=ALASKA,
+        )
+
+
+# --- multi-service index selection -----------------------------------------
+
+from terrain_stitcher.arcgis.services import AmbiguousServiceError
+
+NAIPPLUS = ImageryService(
+    key="naipplus",
+    label="USGS NAIP Plus",
+    base_url="https://imagery.nationalmap.gov/arcgis/rest/services/USGSNAIPPlus/ImageServer/exportImage",
+    native_pixel_size_m=0.3,
+    srs=3857,
+    coverage=(-15.0, -180.0, 72.0, 180.0),
+)
+
+
+@pytest.fixture()
+def services_multi():
+    return {"alaska_vivid_2023_30cm": ALASKA, "naipplus": NAIPPLUS}
+
+
+def test_select_service_ambiguous_without_index(services_multi):
+    aoi = bbox_latlon_from_radius(61.0, -149.0, 5.0)
+    with pytest.raises(AmbiguousServiceError) as ei:
+        select_service(services_multi, aoi)
+    keys = [s.key for s in ei.value.candidates]
+    # ordered by key for stable indices
+    assert keys == ["alaska_vivid_2023_30cm", "naipplus"]
+
+
+def test_select_service_ambiguous_index_selects(services_multi):
+    aoi = bbox_latlon_from_radius(61.0, -149.0, 5.0)
+    assert select_service(services_multi, aoi, index=0).key == "alaska_vivid_2023_30cm"
+    assert select_service(services_multi, aoi, index=1).key == "naipplus"
+
+
+def test_select_service_index_out_of_range(services_multi):
+    aoi = bbox_latlon_from_radius(61.0, -149.0, 5.0)
+    with pytest.raises(ValueError, match="out of range"):
+        select_service(services_multi, aoi, index=5)
+
+
+def test_select_service_picks_the_single_fully_covering_service(services_multi):
+    # Big AOI: center is inside both, but only the nationwide layer fully
+    # contains it -> no disambiguation needed.
+    aoi = bbox_latlon_from_radius(61.0, -149.0, 700.0)
+    assert select_service(services_multi, aoi).key == "naipplus"
+
+
+def test_download_arcgis_ambiguous_prints_list_and_exits(monkeypatch, tmp_path, capsys):
+    """With no --service-index and multiple covering services, the download
+    prints the candidate list with indices and exits (no network)."""
+    import json as _json
+    import pytest
+    from terrain_stitcher.functions import OrthoDownloader
+
+    shape = tmp_path / "Shape.json"
+    shape.write_text(
+        _json.dumps(
+            {
+                "boundsType": "POINT",
+                "center": {"x": -149.0, "y": 61.0},
+                "view_distance": 5.0,
+            }
+        )
+    )
+    monkeypatch.setattr(
+        OrthoDownloader,
+        "load_services",
+        lambda: {"alaska_vivid_2023_30cm": ALASKA, "naipplus": NAIPPLUS},
+    )
+    # Guard against any accidental network call.
+    import requests as _requests
+
+    monkeypatch.setattr(
+        _requests,
+        "get",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("network")),
+    )
+
+    with pytest.raises(SystemExit) as ei:
+        OrthoDownloader.download_from_arcgis(
+            shapefile_path=str(shape),
+            outdir=str(tmp_path / "out"),
+            zoom=18,
+            xyz=True,
+            resampling="lanczos",
+            processes=1,
+            timeout=30,
+            num_workers=1,
+            chunk_px=256,
+        )
+    assert ei.value.code == 2
+    out = capsys.readouterr().out
+    assert "--service-index" in out
+    assert "0:" in out and "1:" in out
+    assert "alaska_vivid_2023_30cm" in out and "naipplus" in out
+
+
+# --- capability kinds -------------------------------------------------------
+
+
+def test_kinds_default_to_imagery():
+    svc = ImageryService(
+        key="x",
+        label="X",
+        base_url="http://example/x/ImageServer/exportImage",
+        native_pixel_size_m=0.5,
+        srs=3857,
+        coverage=(10.0, -100.0, 20.0, -90.0),
+    )
+    assert svc.kinds == ["imagery"]
+    assert svc.supports_kind("imagery")
+    assert not svc.supports_kind("elevation")
+
+
+def test_kinds_roundtrip():
+    svc = ImageryService(
+        key="x",
+        label="X",
+        base_url="http://example/x/ImageServer/exportImage",
+        native_pixel_size_m=10.0,
+        srs=3857,
+        coverage=(10.0, -100.0, 60.0, -50.0),
+        kinds=["elevation"],
+    )
+    d = svc.to_dict()
+    assert d["kinds"] == ["elevation"]
+    assert ImageryService.from_dict(d) == svc
+
+
+def test_from_dict_defaults_kinds_to_imagery():
+    d = {
+        "key": "x",
+        "label": "X",
+        "base_url": "http://example/x/ImageServer/exportImage",
+        "native_pixel_size_m": 0.5,
+        "srs": 3857,
+        "coverage": [10.0, -100.0, 20.0, -90.0],
+    }
+    svc = ImageryService.from_dict(d)
+    assert svc.kinds == ["imagery"]
+
+
+# --- kind filtering in selection ---------------------------------------------
+
+
+def _svc(key, kinds):
+    return ImageryService(
+        key=key,
+        label=key,
+        base_url=f"http://example/{key}/ImageServer/exportImage",
+        native_pixel_size_m=10.0,
+        srs=3857,
+        coverage=(10.0, -100.0, 60.0, -50.0),
+        kinds=kinds,
+    )
+
+
+def test_select_service_filters_by_kind():
+    services = {
+        "ortho": _svc("ortho", ["imagery"]),
+        "dem": _svc("dem", ["elevation"]),
+        "both": _svc("both", ["imagery", "elevation"]),
+    }
+    aoi = bbox_latlon_from_radius(40.0, -90.0, 5.0)
+    # imagery selection only considers imagery + both-tagged services; the
+    # elevation-only "dem" must not appear among the candidates.
+    with pytest.raises(AmbiguousServiceError) as ei:
+        select_service(services, aoi, kind="imagery")
+    assert [s.key for s in ei.value.candidates] == ["both", "ortho"]
+    # elevation selection only considers elevation + both-tagged services;
+    # the imagery-only "ortho" must not appear.
+    with pytest.raises(AmbiguousServiceError) as ei:
+        select_service(services, aoi, kind="elevation")
+    assert [s.key for s in ei.value.candidates] == ["both", "dem"]
+
+
+def test_select_service_elevation_ignores_imagery_only():
+    """An imagery-only service must never satisfy an elevation request."""
+    services = {
+        "ortho": _svc("ortho", ["imagery"]),
+        "dem": _svc("dem", ["elevation"]),
+    }
+    aoi = bbox_latlon_from_radius(40.0, -90.0, 5.0)
+    # The imagery-only service alone covers the center, but for elevation the
+    # only candidate is the DEM.
+    assert select_service(services, aoi, kind="elevation").key == "dem"
+    # For imagery, the DEM is not a candidate, so the imagery-only service is
+    # selected (proving the elevation-only service is ignored for imagery).
+    assert select_service(services, aoi, kind="imagery").key == "ortho"

--- a/tests/test_services_discovery.py
+++ b/tests/test_services_discovery.py
@@ -1,0 +1,206 @@
+import json
+
+import pytest
+import requests as _requests
+
+from terrain_stitcher.arcgis import services as services_mod
+from terrain_stitcher.arcgis.services import (
+    _endpoint_url,
+    harvest_from_file,
+    harvest_from_items,
+    load_services,
+    refresh_services,
+)
+
+ROOT = "https://example.test/nrcs/rest/services"
+ALASKA_URL = f"{ROOT}/ortho_imagery/alaska_vivid_2023_30cm/ImageServer"
+NAIP_URL = f"{ROOT}/naip/naip_2023_tx/ImageServer"
+
+META = {
+    "fullExtent": {
+        "xmin": -10000000.0,
+        "ymin": 5000000.0,
+        "xmax": -9000000.0,
+        "ymax": 6000000.0,
+        "spatialReference": {"wkid": 102100, "latestWkid": 3857},
+    },
+    "tileInfo": {"lods": [{"resolution": 0.2985}, {"resolution": 1.19}]},
+}
+
+
+class _FakeResp:
+    def __init__(self, payload):
+        self._p = payload
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._p
+
+
+def _fake_get(url, params=None, timeout=None):
+    # Any ImageServer endpoint returns metadata.
+    return _FakeResp(META)
+
+
+def test_endpoint_url_normalizes_exportimage():
+    assert _endpoint_url(f"{ALASKA_URL}/exportImage") == ALASKA_URL
+    assert _endpoint_url(ALASKA_URL) == ALASKA_URL
+    assert _endpoint_url({"url": f"{ALASKA_URL}/exportImage"}) == ALASKA_URL
+
+
+def test_endpoint_url_rejects_bad_entries():
+    with pytest.raises(ValueError, match="missing 'url'"):
+        _endpoint_url({"recursive": True})
+    with pytest.raises(ValueError, match="unsupported endpoint entry type"):
+        _endpoint_url(42)
+
+
+def test_harvest_from_items_fetches_each_endpoint(monkeypatch):
+    monkeypatch.setattr(_requests, "get", _fake_get)
+    data = harvest_from_items([ALASKA_URL, NAIP_URL])
+    bases = sorted(s["base_url"] for s in data["services"])
+    assert bases == sorted([f"{ALASKA_URL}/exportImage", f"{NAIP_URL}/exportImage"])
+    # coverage reprojected to a WGS84 4-tuple
+    assert len(data["services"][0]["coverage"]) == 4
+    assert len(data["services"]) == 2
+
+
+def test_harvest_from_items_dedupes(monkeypatch):
+    monkeypatch.setattr(_requests, "get", _fake_get)
+    data = harvest_from_items([ALASKA_URL, ALASKA_URL])
+    assert len(data["services"]) == 1
+
+
+def test_harvest_from_file_array(monkeypatch, tmp_path):
+    monkeypatch.setattr(_requests, "get", _fake_get)
+    f = tmp_path / "endpoints.json"
+    f.write_text(json.dumps([ALASKA_URL]))
+    data = harvest_from_file(str(f))
+    assert len(data["services"]) == 1
+    assert data["services"][0]["base_url"] == f"{ALASKA_URL}/exportImage"
+
+
+def test_harvest_from_file_folders_wrapper(monkeypatch, tmp_path):
+    monkeypatch.setattr(_requests, "get", _fake_get)
+    f = tmp_path / "endpoints.json"
+    f.write_text(json.dumps({"folders": [ALASKA_URL]}))
+    data = harvest_from_file(str(f))
+    assert len(data["services"]) == 1
+
+
+def test_refresh_services_default_uses_shipped_scan_list(monkeypatch, tmp_path):
+    monkeypatch.setattr(_requests, "get", _fake_get)
+    monkeypatch.setattr(services_mod, "_shipped_scan_items", lambda: [ALASKA_URL])
+    cache = tmp_path / "services.json"
+    monkeypatch.setattr(services_mod, "_cache_path", lambda: cache)
+    refresh_services()
+    assert cache.is_file()
+    assert len(load_services()) == 1
+
+
+def test_refresh_services_from_file(monkeypatch, tmp_path):
+    monkeypatch.setattr(_requests, "get", _fake_get)
+    scan = tmp_path / "scan.json"
+    scan.write_text(json.dumps([ALASKA_URL, NAIP_URL]))
+    cache = tmp_path / "services.json"
+    monkeypatch.setattr(services_mod, "_cache_path", lambda: cache)
+    refresh_services(from_file=str(scan))
+    assert cache.is_file()
+    assert len(load_services()) == 2
+
+
+# --- pixel_size declared on scan-list entries -------------------------------
+
+
+def test_item_pixel_size_returns_declared_value():
+    from terrain_stitcher.arcgis.services import _item_pixel_size
+
+    assert _item_pixel_size({"url": "http://x", "pixel_size": 0.3}) == 0.3
+    assert _item_pixel_size({"url": "http://x"}) is None
+    assert _item_pixel_size("http://x") is None
+
+
+def test_harvest_uses_declared_pixel_size(monkeypatch):
+    """A scan-list object may declare pixel_size; it overrides metadata even
+    when the service exposes no tileInfo (e.g. USGSNAIPPlus)."""
+    import requests as _requests
+    from terrain_stitcher.arcgis.services import harvest_from_items
+
+    # USGSNAIPPlus-like metadata: no tileInfo, minPixelSize 0, pixelSizeX 0.3.
+    mosaic_meta = {
+        "fullExtent": {
+            "xmin": -10000000.0,
+            "ymin": 5000000.0,
+            "xmax": -9000000.0,
+            "ymax": 6000000.0,
+            "spatialReference": {"wkid": 102100, "latestWkid": 3857},
+        },
+        "tileInfo": None,
+        "minPixelSize": 0,
+        "pixelSizeX": 0.3,
+    }
+
+    class _Resp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return mosaic_meta
+
+    monkeypatch.setattr(_requests, "get", lambda *a, **k: _Resp())
+    data = harvest_from_items(
+        [{"url": "https://example.test/svc/ImageServer", "pixel_size": 0.3}]
+    )
+    assert len(data["services"]) == 1
+    assert data["services"][0]["native_pixel_size_m"] == 0.3
+
+
+def test_native_pixel_size_falls_back_to_pixel_size_x():
+    """When no pixel_size is declared and there is no tileInfo, the metadata
+    fallback uses pixelSizeX (fixing the previous 0.0 bug)."""
+    from terrain_stitcher.arcgis.services import _native_pixel_size
+
+    assert (
+        _native_pixel_size({"tileInfo": None, "minPixelSize": 0, "pixelSizeX": 0.3})
+        == 0.3
+    )
+    import pytest
+
+    with pytest.raises(ValueError):
+        _native_pixel_size({"tileInfo": None, "minPixelSize": 0})
+
+
+# --- capability kinds stamped from scan-list entries ------------------------
+
+
+def test_item_kinds_defaults_to_imagery():
+    from terrain_stitcher.arcgis.services import _item_kinds
+
+    assert _item_kinds("http://x") == ["imagery"]
+    assert _item_kinds({"url": "http://x"}) == ["imagery"]
+    assert _item_kinds({"url": "http://x", "kinds": ["elevation"]}) == ["elevation"]
+    # unknown values are filtered out, degrading to the default
+    assert _item_kinds({"url": "http://x", "kinds": ["bogus"]}) == ["imagery"]
+
+
+def test_harvest_stamps_kinds_from_scan_entry(monkeypatch):
+    """An object scan entry declaring kinds=["elevation"] must register the
+    service with that capability, and one without kinds stays imagery."""
+    import requests as _requests
+    from terrain_stitcher.arcgis.services import harvest_from_items
+
+    monkeypatch.setattr(_requests, "get", _fake_get)
+    data = harvest_from_items(
+        [
+            {"url": f"{ALASKA_URL}", "kinds": ["elevation"]},
+            {"url": f"{NAIP_URL}"},
+        ]
+    )
+    by_key = {s["key"]: s for s in data["services"]}
+    assert len(data["services"]) == 2
+    elev_keys = [k for k, s in by_key.items() if s["kinds"] == ["elevation"]]
+    imagery_keys = [k for k, s in by_key.items() if s["kinds"] == ["imagery"]]
+    assert len(elev_keys) == 1
+    assert len(imagery_keys) == 1


### PR DESCRIPTION
This issue involved implementing support for downloading from multiple states. Previously, the downloader had a hardcoded endpoint at a single alaska site. USGS provides a service which holds many states. This can be used instead or alongside the specific Alaska data.